### PR TITLE
docs-sync could never push an already-committed change

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -326,27 +326,59 @@
          ;; `git commit` are both scoped to `path` explicitly — never -A/. —
          ;; because b12n-wikis is SHARED across many projects and a stray
          ;; staged file from a concurrent session must not ride along.
+         ;; Commit if there is anything to commit, then push if the branch is
+         ;; ahead — the two are checked SEPARATELY on purpose. An earlier
+         ;; version returned :skipped whenever the tree was clean, which meant
+         ;; a commit that was already made but never pushed (a prior run that
+         ;; stopped at --no-push, or a hand commit) could never be pushed by
+         ;; this task at all: it reported "up to date" and left the branch
+         ;; ahead of origin indefinitely.
          sync!     (fn [opts]
                      (let [label (:label opts) dir (:dir opts)
                            path (:path opts) msg (:msg opts)]
                        (hdr label)
-                       (if-not (dirty? dir path)
-                         (do (println "  up to date, nothing to commit") :skipped)
-                         (do
-                           (shell {:dir dir} "git" "add" "--" path)
-                           (shell {:dir dir} "git" "commit" "-m" msg "--" path)
-                           (if-not push?
-                             (do (println "  committed locally (--no-push)") :ok)
-                             (do
-                               (shell {:dir dir :continue true} "git" "fetch" "origin")
-                               (let [res (shell {:dir dir :out :string} "git" "status" "--short" "--branch")]
-                                 (if (str/includes? (:out res) "behind")
-                                   (do (println (str "  BEHIND origin — resolve manually (cd " dir " && git pull --rebase), not auto-pushing"))
-                                       :behind)
-                                   (let [pr (shell {:dir dir :continue true} "git" "push" "origin" "main")]
-                                     (if (zero? (:exit pr))
-                                       (do (println "  pushed") :ok)
-                                       (do (println "  PUSH FAILED") :push-failed)))))))))))
+                       (let [committed? (if (dirty? dir path)
+                                          (do (shell {:dir dir} "git" "add" "--" path)
+                                              (shell {:dir dir} "git" "commit" "-m" msg "--" path)
+                                              true)
+                                          false)]
+                         (if-not push?
+                           (do (println (if committed?
+                                          "  committed locally (--no-push)"
+                                          "  nothing to commit (--no-push)"))
+                               :ok)
+                           (do
+                             (shell {:dir dir :continue true} "git" "fetch" "origin")
+                             ;; One status read, used for both checks, so a
+                             ;; diverged branch cannot slip between them.
+                             (let [st (:out (shell {:dir dir :out :string} "git" "status" "--short" "--branch"))]
+                               (cond
+                                 (str/includes? st "behind")
+                                 (do (println (str "  BEHIND origin — resolve manually (cd " dir " && git pull --rebase), not auto-pushing"))
+                                     :behind)
+
+                                 ;; No upstream means the status line carries no
+                                 ;; ahead/behind at all, so the check below would
+                                 ;; read as "nothing to push" and skip silently -
+                                 ;; the same failure this fn was just fixed for.
+                                 ;; git filter-repo drops the remote, so a repo
+                                 ;; can land here after a history rewrite.
+                                 (not (str/includes? st "..."))
+                                 (do (println (str "  NO UPSTREAM for main in " dir " — not pushing."))
+                                     (println "  Fix with: git branch --set-upstream-to=origin/main main")
+                                     :no-upstream)
+
+                                 (not (str/includes? st "ahead"))
+                                 (do (println "  up to date, nothing to push") :skipped)
+
+                                 :else
+                                 (let [pr (shell {:dir dir :continue true} "git" "push" "origin" "main")]
+                                   (if (zero? (:exit pr))
+                                     (do (println (if committed?
+                                                    "  committed + pushed"
+                                                    "  pushed (commit was already local)"))
+                                         :ok)
+                                     (do (println "  PUSH FAILED") :push-failed))))))))))
          ;; Publishes the BUILT site (not the git repo) to the S3 origin
          ;; behind CloudFront, then invalidates the edge cache. Provisioned
          ;; by ~/dev/b12n-infra's static-site module
@@ -421,7 +453,7 @@
              (println (str "  site:   " site-result))
              (println (str "  wiki:   " wiki-result))
              (println (str "  deploy: " deploy-result))
-             (when (some (fn [r] (contains? #{:behind :push-failed :build-failed
+             (when (some (fn [r] (contains? #{:behind :push-failed :build-failed :no-upstream
                                               :sync-failed :invalidation-failed} r))
                          [site-result wiki-result deploy-result])
                (System/exit 1)))))))}


### PR DESCRIPTION
`docs-sync` could never push a commit it didn't make in that same run.

Found in [b12n-raylib-jnk](https://github.com/burinc/b12n-raylib-jnk), which ported this task from here — so the same bug was here.

## The bug

`sync!` decided commit-and-push as one thing:

```clojure
(if-not (dirty? dir path)
  (do (println "  up to date, nothing to commit") :skipped)   ; <- push unreachable
  (do ...commit... ...push...))
```

If the tree was clean it returned `:skipped` immediately, so the push branch was unreachable. A commit already made but not yet pushed — from a prior `--no-push` run, or made by hand — could never be pushed by this task at all. It reported "up to date" and left the branch ahead of origin indefinitely.

Not theoretical. In the sibling repo, `docs-sync` reported `site: :skipped` and `wiki: :skipped` on its first real run, and three repos were still ahead of origin afterwards.

## The fix

Commit and push are decided **separately**. Commit if the tree is dirty; then fetch and push if the branch is ahead, whether or not this run was what committed.

Also catches a **missing upstream** explicitly. Without that, the status line carries no ahead/behind at all, so the ahead check reads as "nothing to push" — the same silent-skip failure through a different door. `git filter-repo` drops the remote, so a repo can land in that state after a history rewrite.

Behind is still checked first, and it still refuses to auto-rebase or force-push. The branch status is read **once** and used for both checks, so a diverged branch can't slip between two reads.

Output now distinguishes the cases instead of flattening them: `committed + pushed`, `pushed (commit was already local)`, `up to date, nothing to push`, and under `--no-push`, `nothing to commit` rather than claiming a commit that didn't happen.

## Verification

The fn is **character-identical** (3017 chars, diffed) to the one in b12n-raylib-jnk, which was verified against scratch repos in all four states:

| state | result |
|---|---|
| dirty + ahead | commits and pushes |
| clean + ahead — **the broken case** | pushes |
| clean + synced | skips |
| no upstream | reports, doesn't skip silently |

`bb lib:check`, `bb check` (all 75 examples) and `bb lint:strict` pass, and the pre-commit hook reports clojure-lsp `Nothing to format!` / `Nothing to clear!`.

One caveat: `bb lsp:format-check` itself errors on my machine — that path wants a clojure CLI it can't download through my proxy, then falls back to a `clojure` that's a mise shim rejecting its `-X`. That failure predates this change and reproduces on `main`; CI installs a real CLI, and the hook verified formatting anyway.
