### PR TITLE
style(docs): remove em-dashes from the docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 
 - [ ] `bb check` passes (headless compile-check of every example)
 - [ ] `bb lint:strict` passes (clj-kondo, non-zero exit on any finding)
-- [ ] `bb lsp:format-check` passes (clojure-lsp formatting — **not** cljfmt)
+- [ ] `bb lsp:format-check` passes (clojure-lsp formatting, **not** cljfmt)
 
 ## If this adds an example
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@ Thanks for taking an interest. This is a suite of [raylib](https://github.com/ra
 examples written in [jolt](https://github.com/jolt-lang) (native Clojure, no JVM),
 calling the real `libraylib` over its C ABI through `jolt.ffi`.
 
-New examples are very welcome — the suite is deliberately mechanical to grow.
+New examples are very welcome; the suite is deliberately mechanical to grow.
 
 The documentation is published at <https://raylib-jlt.b12n.app>. It's generated from
-this repo's `docs/guide/` — edit the Markdown here, never the site.
+this repo's `docs/guide/`; edit the Markdown here, never the site.
 
 ## Setting up
 
@@ -22,7 +22,7 @@ If `bb lib:check` says no, `bb lib:install` will install it via your platform's
 package manager (brew / pacman / apt / dnf / zypper / apk), or `bb lib:install
 --dry-run` prints the command it would run so you can do it yourself.
 
-[babashka](https://babashka.org) is optional but makes everything friendlier —
+[babashka](https://babashka.org) is optional but makes everything friendlier:
 every example has a `bb <name>` task. Without it, use `jolt -M:<alias>` directly.
 
 ## Before you open a PR
@@ -36,7 +36,7 @@ bb lsp:format-check   # clojure-lsp formatting, dry run
 ```
 
 `bb lsp:fix` applies formatting and ns cleanup in place if `lsp:format-check`
-complains. **Formatting is owned by clojure-lsp, not cljfmt** — please don't run
+complains. **Formatting is owned by clojure-lsp, not cljfmt**; please don't run
 cljfmt over `src`, the two disagree on some compact literal tables.
 
 If you'd like these to run automatically, `bb hooks:install` sets up a local
@@ -44,10 +44,10 @@ pre-commit hook (~2s). It's never committed, so each clone opts in.
 
 ## Adding an example
 
-One new example touches exactly four places. The full recipe — with the source
-layout, the naming rules, and a diagram — lives in the example catalog:
+One new example touches exactly four places. The full recipe (with the source
+layout, the naming rules, and a diagram) lives in the example catalog:
 
-**[docs/guide/example-catalog.md § Adding an example — the four touchpoints](docs/guide/example-catalog.md#adding-an-example--the-four-touchpoints)**
+**[docs/guide/example-catalog.md § Adding an example: the four touchpoints](docs/guide/example-catalog.md#adding-an-example-the-four-touchpoints)**
 
 In short: the source namespace, a `deps.edn` alias, a `check.clj` require, and a
 `bb.edn` registry row. If you skip the `check.clj` require, `bb check` won't cover
@@ -70,7 +70,7 @@ Two rules worth knowing before you write any code:
 If you're touching the binding layer rather than adding an example, read
 [`docs/guide/`](docs/guide/index.md) first. Every non-obvious decision in
 `raylib.clj` traces back to how a particular C struct crosses the FFI boundary,
-and the answer differs per struct — `Color` packs into a `:uint`,
+and the answer differs per struct: `Color` packs into a `:uint`,
 `Camera2D`/`Camera3D` go by pointer, and `Vector2`/`Vector3` geometry has to fall
 back to rlgl immediate mode. Those three pages explain why.
 
@@ -78,7 +78,7 @@ Note the **x86-64 caveat** documented in
 [`struct-by-value-pointer-trick.md`](docs/guide/struct-by-value-pointer-trick.md):
 the `Camera2D`/`Camera3D` pointer trick is AArch64-specific. If you're on x86-64
 and `camera2d` crashes with an invalid memory reference, that's the known cause,
-not a bug in your setup — and a portable rlgl-matrix replacement would be a
+not a bug in your setup, and a portable rlgl-matrix replacement would be a
 genuinely valuable contribution.
 
 ## Verifying a windowed example without watching it
@@ -99,17 +99,17 @@ batched-geometry flush makes the screenshot non-empty.
 You don't need to record anything. Every GIF under `docs/demos/` is committed, and
 `docs/demos/README.md` is generated from `scripts/demo_manifest.edn`. The `bb
 record` task drives an internal capture tool that isn't publicly released, so it's
-maintainer-only — it will tell you so rather than failing obscurely. If your new
+maintainer-only; it will tell you so rather than failing obscurely. If your new
 example would benefit from a specific input sequence in its demo, add an
 `:overrides` entry for it in the manifest and mention it in your PR; a maintainer
 will record it.
 
 Publishing the site is likewise a maintainer task (`bb docs-sync`), so a docs change
-in your PR goes live when a maintainer next syncs — you don't need to do anything.
+in your PR goes live when a maintainer next syncs; you don't need to do anything.
 
 ## Licensing
 
-This project is released under the zlib/libpng license — the same license as raylib
+This project is released under the zlib/libpng license, the same license as raylib
 itself. By contributing, you agree your contribution is licensed under those terms.
 If your example is a port of an upstream raylib example, please name the original in
 the README table (e.g. `shapes/shapes_bouncing_ball`) so the attribution stays

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# b12n-raylib-jlt — raylib examples in Jolt
+# b12n-raylib-jlt: raylib examples in Jolt
 
 A community suite of [raylib](https://github.com/raysan5/raylib) examples written in
-**jolt** (native Clojure — no JVM). These call a **real external C library**: raylib is
+**jolt** (native Clojure, no JVM). These call a **real external C library**: raylib is
 the upstream C game library (raysan5/raylib), and jolt binds it directly over its C ABI
-with `jolt.ffi` — no wrapper library, no codegen, just the shared `libraylib` loaded at
+with `jolt.ffi`: no wrapper library, no codegen, just the shared `libraylib` loaded at
 runtime and called through the FFI.
 
 All the FFI bindings and an ergonomic keyword-argument drawing API live in one
 shared namespace, `net.b12n.raylib-jlt.raylib`; each example is a small namespace on top of it.
 
-**Documentation site: <https://raylib-jlt.b12n.app>** — the guide, the full example
+**Documentation site: <https://raylib-jlt.b12n.app>** carries the guide, the full example
 catalog, and every demo GIF at full size.
 
 ## Examples
@@ -38,7 +38,7 @@ catalog, and every demo GIF at full size.
 </tr>
 </table>
 
-**[Browse the full gallery →](docs/demos/README.md)** — every example, recorded via `bb record`.
+**[Browse the full gallery →](docs/demos/README.md)**: every example, recorded via `bb record`.
 `bb record --only <example-name>` matches an exact id or an id prefix
 (e.g. `--only camera-3d` also selects `camera-3d-first-person`); combine a
 short prefix with `--force` carefully.
@@ -69,12 +69,12 @@ Unhandled exception: Unable to resolve symbol: rgba in this context
 
 This is why the `Color` section (`rgba` plus the named palette) sits at the top of
 the file, above `shade-color` / `cube!` / `sphere!` which use it. Compilation stops
-at the first unresolved symbol, so fix them one at a time — `jolt -M:check`
+at the first unresolved symbol, so fix them one at a time. `jolt -M:check`
 compiles every example namespace headlessly and is the quickest confirmation that
 the suite still loads.
 
 The launcher is `jolt`. It was called `joltc` before jolt 0.5.0, and current
-releases install only `jolt` — so if a `joltc` shim is still on your PATH from an older
+releases install only `jolt`, so if a `joltc` shim is still on your PATH from an older
 install, every `jolt -M:<alias>` below works under that name too. The `bb` tasks
 resolve whichever one you have.
 
@@ -103,7 +103,7 @@ sudo pacman -S raylib        # Arch Linux
 
 **Using a source build of raylib** (e.g. from `~/dev/raylib`): build the shared
 library (`cmake --build build`), then point the dynamic loader at it instead of
-installing system-wide —
+installing system-wide:
 
 ```sh
 export LD_LIBRARY_PATH=$HOME/dev/raylib/build/raylib    # Linux
@@ -129,7 +129,7 @@ bb lib:install          # install libraylib via the platform package manager
 bb tasks                # raw babashka task list
 ```
 
-Two more exist for maintaining the published docs — both explain themselves and stop
+Two more exist for maintaining the published docs; both explain themselves and stop
 cleanly if their external tooling isn't available:
 
 ```sh
@@ -139,17 +139,17 @@ bb docs-sync    # rebuild + publish the documentation site; --no-push to stay lo
 
 The `bb` names are friendly aliases; each maps to a `jolt` alias below.
 
-#### Quality — lint / format / checks
+#### Quality: lint / format / checks
 
 ```sh
 bb lint                          # clj-kondo over src (report only)
 bb lint:strict                   # bb lint, but exit non-zero if any findings
 bb lsp:format                    # reformat all Clojure files (clojure-lsp)
-bb lsp:format-check              # check formatting — dry run
+bb lsp:format-check              # check formatting (dry run)
 bb lsp:clean-ns                  # clean + organize ns forms (clojure-lsp)
-bb lsp:clean-ns-check            # check ns forms — dry run
+bb lsp:clean-ns-check            # check ns forms (dry run)
 bb lsp:diagnostics               # clojure-lsp diagnostics
-bb lsp:check                     # all LSP checks (format + clean-ns + diagnostics) — dry run
+bb lsp:check                     # all LSP checks (format + clean-ns + diagnostics, dry run)
 bb lsp:fix                       # auto-fix: format + clean-ns (mutating)
 bb check:positional-args         # find fns with 3+ positional args (report only)
 bb check:positional-args:strict  # bb check:positional-args, but exit non-zero if any found
@@ -158,23 +158,23 @@ bb check:positional-args:strict  # bb check:positional-args, but exit non-zero i
 `bb check` and `bb lint`/`bb lsp:format-check` are the gates worth running before a
 commit: `check` compiles every example namespace, `lint` runs clj-kondo (static
 analysis), `lsp:format-check` runs clojure-lsp (formatting). **Formatting is owned
-by clojure-lsp, not cljfmt** — the two disagree on some compact literal tables
+by clojure-lsp, not cljfmt**; the two disagree on some compact literal tables
 (e.g. `digital_clock.clj`'s seven-segment map), so only one formatter runs against
 `src`; clojure-lsp was chosen so `lsp:clean-ns` (no cljfmt equivalent) and
 `lsp:format` share one tool. `bb lsp:fix` applies both format and clean-ns fixes
 in place.
 
-`lint` needs [clj-kondo](https://github.com/clj-kondo/clj-kondo) — it uses the
+`lint` needs [clj-kondo](https://github.com/clj-kondo/clj-kondo); it uses the
 native binary when installed and falls back to the
 [clojure CLI](https://clojure.org/guides/install_clojure) route otherwise. The
 `lsp:*` tasks need [clojure-lsp](https://clojure-lsp.io) on `PATH`. Nothing in the
-suite needs a JVM at *runtime* — these are dev-time tools only.
+suite needs a JVM at *runtime*; these are dev-time tools only.
 
 clj-kondo can't see through `jolt.ffi/defcfn`, which defines one var per bound C
-symbol — untaught, it reports ~500 false positives and is useless as a gate. The
+symbol; untaught, it reports ~500 false positives and is useless as a gate. The
 hook in [`.clj-kondo/hooks/jolt_ffi.clj`](.clj-kondo/hooks/jolt_ffi.clj) rewrites
 each `defcfn` into an equivalent `defn`, so the bindings resolve *and* call sites
-get arity- and return-type-checked — catching `(rl/init-window 1 2)` at lint time
+get arity- and return-type-checked, catching `(rl/init-window 1 2)` at lint time
 instead of as a native crash.
 
 #### Git hooks
@@ -185,7 +185,7 @@ bb hooks:install:full  # install FULL pre-commit hook (+ bb check, slower)
 bb hooks:uninstall     # remove the git pre-commit hook
 ```
 
-The pre-commit hook is local-only (`.git/hooks/pre-commit` is never committed) —
+The pre-commit hook is local-only (`.git/hooks/pre-commit` is never committed);
 each clone that wants it runs `bb hooks:install` once. Skip it for a single commit
 with `git commit --no-verify`.
 
@@ -217,9 +217,9 @@ jolt -M:check      # requires every example namespace; prints "compiled OK"
 
 ### Environment variables (used by every example)
 
-- `RAYLIB_APP_AUTO_QUIT_MS=<n>` — close the window after `n` milliseconds, so an
+- `RAYLIB_APP_AUTO_QUIT_MS=<n>`: close the window after `n` milliseconds, so an
   example is smoke-testable with no person at the keyboard.
-- `RAYLIB_APP_SHOT=<name>` — dump one frame as a PNG (headless visual proof). raylib
+- `RAYLIB_APP_SHOT=<name>`: dump one frame as a PNG (headless visual proof). raylib
   writes the file's **basename into the current working directory** (it ignores
   directory components), and the batched text is flushed first so it appears.
 
@@ -239,7 +239,7 @@ jolt -M:check      # requires every example namespace; prints "compiled OK"
 | `logo` | (raylib logo) | rectangles + text, positioned with `MeasureText` |
 | `stars` | (showcase) | `GetRandomValue` + bulk draw, per-star twinkle |
 | `eyes` | shapes/shapes_following_eyes | pupils track the mouse (scalar trig) |
-| `camera2d` | core/core_2d_camera | 2D camera — struct-by-value (see note) |
+| `camera2d` | core/core_2d_camera | 2D camera, struct-by-value (see note) |
 | `delta-time` | core/core_delta_time | per-frame vs `GetFrameTime` movement |
 | `scissor-test` | core/core_scissor_test | `BeginScissorMode` clips a grid |
 | `mouse-trail` | shapes/shapes_mouse_trail | fading cursor trail (alpha) |
@@ -258,7 +258,7 @@ jolt -M:check      # requires every example namespace; prints "compiled OK"
 | `hilbert-curve` | shapes | a rainbow Hilbert space-filling curve |
 | `math-angle-rotation` | shapes/shapes_math_angle_rotation | fixed spokes + a spinning line |
 | `words-alignment` | text/text_words_alignment | align a word with `MeasureText` |
-| `camera-3d` | core/core_3d_camera | orbiting 3D camera — `Camera3D` by value + rlgl cube |
+| `camera-3d` | core/core_3d_camera | orbiting 3D camera, `Camera3D` by value + rlgl cube |
 | `waving-cubes` | models/models_waving_cubes | 196 cubes rippling in 3D (shared `rl/cube!`) |
 | `camera-3d-first-person` | core/core_3d_camera_first_person | WASD + mouse-look walk through columns |
 | `tesseract-view` | (4D) | a rotating 4D hypercube projected 4D→3D→2D |
@@ -273,18 +273,18 @@ jolt -M:check      # requires every example namespace; prints "compiled OK"
 | `ball-physics` | shapes | 2D balls under gravity + restitution |
 | `lines-bezier` | shapes/shapes_lines_bezier | a cubic Bézier sampled in Clojure, follows the mouse |
 | `input-box` | text/text_input_box | a text field via `GetCharPressed` (blinking cursor) |
-| `asteroids` | (game) | the classic vector shooter — rotate/thrust/fire, splitting asteroids |
+| `asteroids` | (game) | the classic vector shooter: rotate/thrust/fire, splitting asteroids |
 | `tetris` | (game) | 10×20 well, 7 tetrominoes, rotation, line-clearing, levels |
 | `pong` | (game) | two-paddle classic, you (W/S) vs a ball-tracking CPU |
-| `vampire-survivors` | (game) | auto-firing survivors-like — chasing waves, XP gems, leveling |
-| `snake` | (game) | the classic snake — arrow keys, grow, don't crash |
+| `vampire-survivors` | (game) | auto-firing survivors-like: chasing waves, XP gems, leveling |
+| `snake` | (game) | the classic snake: arrow keys, grow, don't crash |
 | `breakout` | (game) | paddle (mouse) + ball + brick grid, clear to win |
 | `space-invaders` | (game) | marching alien grid, shoot up (arrows + SPACE) |
 | `flappy-bird` | (game) | flap through scrolling pipe gaps (SPACE) |
-| `game-2048` | (game) | **2048** — 4×4 tile-merge puzzle (arrow keys) |
-| `minesweeper` | (game) | reveal/flag grid, flood-fill (mouse L/R) — new `mouse-pressed?` |
+| `game-2048` | (game) | **2048**: 4×4 tile-merge puzzle (arrow keys) |
+| `minesweeper` | (game) | reveal/flag grid, flood-fill (mouse L/R), new `mouse-pressed?` |
 | `game-of-life` | (generative) | Conway's Game of Life on a toroidal grid (SPACE reseeds) |
-| `boids` | (generative) | Reynolds flocking — separation / alignment / cohesion |
+| `boids` | (generative) | Reynolds flocking: separation / alignment / cohesion |
 | `fireworks` | (generative) | rockets + gravity-fading particle bursts (alpha channel) |
 | `fourier-epicycles` | (generative) | a chain of rotating circles traces a square wave |
 | `spirograph` | (generative) | animated hypotrochoid roulette curves |
@@ -293,10 +293,10 @@ jolt -M:check      # requires every example namespace; prints "compiled OK"
 | `color-wheel` | shapes/shapes_rlgl_color_wheel | an HSV hue ring as an rlgl triangle fan (per-vertex color) |
 | `pie-chart` | shapes/shapes_pie_chart | labelled slices via `rl/sector!` + a legend |
 | `splines` | shapes/shapes_splines_drawing | Catmull-Rom / Bézier / B-spline through animated points (SPACE cycles) |
-| `vector-angle` | shapes/shapes_vector_angle | the signed angle between two vectors — arc + degrees (`atan2`) |
+| `vector-angle` | shapes/shapes_vector_angle | the signed angle between two vectors: arc + degrees (`atan2`) |
 | `easings` | shapes/shapes_easings_* | a 3×4 grid of balls, each on a different easing curve |
 | `penrose-tiling` | shapes/shapes_penrose_tile | a P3 Penrose rhombus tiling by golden-ratio deflation |
-| `analog-clock` | shapes/shapes_clock_of_clocks | a live analog clock — `ring!` bezel, `line-ex!` ticks/hands, **libc** local time |
+| `analog-clock` | shapes/shapes_clock_of_clocks | a live analog clock: `ring!` bezel, `line-ex!` ticks/hands, **libc** local time |
 | `digital-clock` | shapes/shapes_digital_clock | a seven-segment `HH:MM:SS` display (libc local time) |
 | `ring-drawing` | shapes/shapes_ring_drawing | an animated annulus via `rl/ring!` + a stroked outline |
 | `rounded-rectangle` | shapes/shapes_rounded_rectangle_drawing | rounded rects from `sector!` corners + rects |
@@ -342,52 +342,52 @@ calls so examples read self-descriptively:
 
 A few raylib calls (e.g. `DrawTriangle`) take `Vector2` by value, which does **not**
 reduce to the `Color` trick (a 2-float struct goes in floating-point registers). The
-`shapes` example draws its triangle with rlgl's scalar immediate mode instead —
+`shapes` example draws its triangle with rlgl's scalar immediate mode instead:
 `rlBegin` / `rlColor4ub` / `rlVertex2f` / `rlEnd`.
 
 ### `Camera2D` struct by value (the `camera2d` example)
 
 raylib's `BeginMode2D(Camera2D)` takes a 24-byte struct by value. On the AArch64
-(Apple) ABI a composite larger than 16 bytes is passed **indirectly** — the caller
-allocates a copy and passes a pointer — so `net.b12n.raylib-jlt.raylib/with-camera-2d` builds the
+(Apple) ABI a composite larger than 16 bytes is passed **indirectly**: the caller
+allocates a copy and passes a pointer, so `net.b12n.raylib-jlt.raylib/with-camera-2d` builds the
 struct in native memory (`ffi/alloc` + six `ffi/write :float`s) and binds
 `BeginMode2D` as `[:pointer]`.
 
 **This is AArch64-specific.** On the x86-64 SysV ABI those 24 bytes are passed on
-the stack, which a `[:pointer]` binding does not do — so this example is not portable
+the stack, which a `[:pointer]` binding does not do, so this example is not portable
 as written. The portable alternative is to apply the same transform with rlgl's
 scalar matrix ops (`rlPushMatrix` / `rlTranslatef` / `rlRotatef` / `rlScalef`,
 flushing the batch before `rlPopMatrix`), which is exactly what `BeginMode2D` does
 internally. If `camera2d` crashes with an "invalid memory reference", the struct
-passing is the cause — switch to the rlgl-matrix approach.
+passing is the cause; switch to the rlgl-matrix approach.
 
 ### 3D: `Camera3D` by value + rlgl geometry (the `camera-3d` example)
 
 The same pointer approach scales to 3D: `BeginMode3D(Camera3D)` takes a 44-byte
 struct (three `Vector3` + `fovy` + `projection`), which is `>16` bytes so it goes
-by pointer too — `net.b12n.raylib-jlt.raylib/with-camera-3d` builds it (`ffi/alloc` 44 +
+by pointer too; `net.b12n.raylib-jlt.raylib/with-camera-3d` builds it (`ffi/alloc` 44 +
 `ffi/write` nine floats + an `:int`). But 3D shape helpers (`DrawCube`,
-`DrawSphere`, `DrawLine3D`) take a `Vector3` **by value** — a 12-byte float struct
+`DrawSphere`, `DrawLine3D`) take a `Vector3` **by value**, a 12-byte float struct
 passed in FP registers, which the pointer trick does **not** cover. So `camera-3d`
 draws its cube with rlgl immediate mode (`rlVertex3f`, scalar) inside `BeginMode3D`;
-`DrawGrid` is scalar and used directly. That combination — `Camera3D` by pointer +
-rlgl for geometry — is the path for any 3D example here until jolt gains native
+`DrawGrid` is scalar and used directly. That combination (`Camera3D` by pointer +
+rlgl for geometry) is the path for any 3D example here until jolt gains native
 by-value struct support for `Vector3`-taking functions.
 
 ## Documentation
 
 Everything below is also published at **<https://raylib-jlt.b12n.app>**, which is the
-nicer way to read it — the guide pages are cross-linked and the demo gallery renders
+nicer way to read it; the guide pages are cross-linked and the demo gallery renders
 inline.
 
-- [`docs/guide/`](docs/guide/index.md) — patterns & pitfalls, each with source
+- [`docs/guide/`](docs/guide/index.md): patterns & pitfalls, each with source
   citations:
-  - [`color-by-value.md`](docs/guide/color-by-value.md) — why `Color` crosses the FFI as a packed `:uint`
-  - [`struct-by-value-pointer-trick.md`](docs/guide/struct-by-value-pointer-trick.md) — `Camera2D`/`Camera3D` by pointer on AArch64 (+ the x86-64 caveat)
-  - [`rlgl-immediate-mode.md`](docs/guide/rlgl-immediate-mode.md) — the fallback for by-value `Vector2`/`Vector3` geometry, + the matrix stack
-  - [`kwarg-drawing-api.md`](docs/guide/kwarg-drawing-api.md) — the positional-binds / keyword-wrappers two-layer design
-  - [`headless-smoke-testing.md`](docs/guide/headless-smoke-testing.md) — `RAYLIB_APP_AUTO_QUIT_MS` + `RAYLIB_APP_SHOT` proof without a person
-  - [`example-catalog.md`](docs/guide/example-catalog.md) — a tour of all 75, and the four-touchpoint recipe for adding one
+  - [`color-by-value.md`](docs/guide/color-by-value.md): why `Color` crosses the FFI as a packed `:uint`
+  - [`struct-by-value-pointer-trick.md`](docs/guide/struct-by-value-pointer-trick.md): `Camera2D`/`Camera3D` by pointer on AArch64 (+ the x86-64 caveat)
+  - [`rlgl-immediate-mode.md`](docs/guide/rlgl-immediate-mode.md): the fallback for by-value `Vector2`/`Vector3` geometry, + the matrix stack
+  - [`kwarg-drawing-api.md`](docs/guide/kwarg-drawing-api.md): the positional-binds / keyword-wrappers two-layer design
+  - [`headless-smoke-testing.md`](docs/guide/headless-smoke-testing.md): `RAYLIB_APP_AUTO_QUIT_MS` + `RAYLIB_APP_SHOT` proof without a person
+  - [`example-catalog.md`](docs/guide/example-catalog.md): a tour of all 75, and the four-touchpoint recipe for adding one
 
 - Two galleries show the same 75 GIFs for different purposes:
   [`docs/demos/README.md`](docs/demos/README.md) is the flat gallery generated by
@@ -399,13 +399,13 @@ inline.
   rebuilds the site, commits the generated output, mirrors the guide pages, and
   deploys to the CDN behind <https://raylib-jlt.b12n.app>. `bb docs-sync --no-push`
   does the rebuild and commits locally without publishing anything. It's a
-  maintainer task — it needs sibling repos and cloud credentials — and it explains
+  maintainer task (it needs sibling repos and cloud credentials), and it explains
   itself and skips rather than failing if either is absent.
 
 The suite has a sibling project, `b12n-tsj`, which binds tree-sitter from Jolt with
 the same `jolt.ffi` mechanism. It is not public yet, but the contrast shapes the FFI
 guides here: tree-sitter passes *and returns* a 32-byte struct by value, so it needs
-a full C shim — raylib's by-value structs stay within what the pointer trick and rlgl
+a full C shim: raylib's by-value structs stay within what the pointer trick and rlgl
 can cover, so this repo needs no shim at all.
 
 ## Layout
@@ -431,18 +431,18 @@ the `net.b12n.raylib-jlt.raylib` API, add a `:<name>` alias to `deps.edn`, add t
 namespace to `net.b12n.raylib-jlt.check` so the headless compile-check covers it, and add
 a registry row to `bb.edn` so it appears in `bb info` / `bb examples` / `bb run-all`.
 The [example catalog](docs/guide/example-catalog.md) walks through all four under
-"Adding an example — the four touchpoints".
+"Adding an example: the four touchpoints".
 
 ## Contributing
 
-New examples are welcome — the suite is deliberately mechanical to grow, and the
+New examples are welcome; the suite is deliberately mechanical to grow, and the
 four touchpoints above are the whole recipe. See [`CONTRIBUTING.md`](CONTRIBUTING.md)
 for setup, the three pre-PR gates (`bb check`, `bb lint:strict`,
 `bb lsp:format-check`), and what to know before touching the shared binding layer.
 
 ## License
 
-Released under the **zlib/libpng license** — see [`LICENSE`](LICENSE).
+Released under the **zlib/libpng license**; see [`LICENSE`](LICENSE).
 Third-party attribution lives in [`NOTICE`](NOTICE).
 
 That's the same license raylib itself uses, chosen deliberately: many examples here
@@ -450,5 +450,5 @@ are Clojure ports of raylib's own example programs (the table above names the
 upstream source for each), so matching licenses lets the original terms carry
 through unchanged. raylib is Copyright (c) 2013-2026 Ramon Santamaria (@raysan5).
 
-This project does not vendor or redistribute raylib — it loads the system-installed
+This project does not vendor or redistribute raylib; it loads the system-installed
 `libraylib` at runtime over its C ABI.

--- a/docs/guide/color-by-value.md
+++ b/docs/guide/color-by-value.md
@@ -1,4 +1,4 @@
-# `Color` passed by value — as a packed `:uint`
+# `Color` passed by value, as a packed `:uint`
 
 Every raylib draw call takes a `Color`. `Color` is a struct passed **by value**,
 and Jolt's FFI (Chez `foreign-procedure`) has no calling convention for a by-value
@@ -19,7 +19,7 @@ void DrawText(const char *text, int x, int y, int fontSize, Color color);
 ```
 
 On both the AArch64 and x86-64 ABIs, a 4-byte struct made entirely of integers
-travels in a **single general-purpose register** — bit-for-bit identical to how a
+travels in a **single general-purpose register**, bit-for-bit identical to how a
 `uint32_t` travels. So a Jolt binding can declare the parameter as `:uint` and pass
 an ordinary integer; the C side reads the same four bytes back as `{r,g,b,a}`. No
 struct marshaling, no shim, no native allocation.
@@ -70,7 +70,7 @@ flowchart LR
 ## Two by-value Colors in one call
 
 `DrawRectangleGradientV` takes **two** `Color` values by value (top and bottom of
-the gradient). Because each is an independent `:uint`, this needs nothing special —
+the gradient). Because each is an independent `:uint`, this needs nothing special,
 just two `:uint` parameters:
 
 ```clojure
@@ -80,7 +80,7 @@ just two `:uint` parameters:
 
 The `gradient` example (`net.b12n.raylib-jlt.gradient`) uses it directly. Two by-value
 structs in one signature would be a real problem if they didn't each collapse to a
-register — this is a second dividend of the register-fit fact.
+register; this is a second dividend of the register-fit fact.
 
 ## Getting the color back out (for rlgl)
 
@@ -109,8 +109,8 @@ structs).
 
 ## See also
 
-- [`struct-by-value-pointer-trick.md`](struct-by-value-pointer-trick.md) — the
+- [`struct-by-value-pointer-trick.md`](struct-by-value-pointer-trick.md): the
   >16-byte case (`Camera2D`/`Camera3D`) that a register can't hold.
-- `b12n-tsj` (the Jolt tree-sitter sibling, not yet public) — its by-value struct
+- `b12n-tsj` (the Jolt tree-sitter sibling, not yet public): its by-value struct
   (`TSNode`) is both large *and* returned, so no register trick saves it and it
   must ship a C shim.

--- a/docs/guide/demos.md
+++ b/docs/guide/demos.md
@@ -1,6 +1,6 @@
 # Full-size demo gallery
 
-Every example at full size — linked from [the example catalog](example-catalog.md)'s preview thumbnails.
+Every example at full size, linked from [the example catalog](example-catalog.md)'s preview thumbnails.
 
 ## games (10)
 

--- a/docs/guide/example-catalog.md
+++ b/docs/guide/example-catalog.md
@@ -1,4 +1,4 @@
-# The example catalog — 75 raylib demos in jolt
+# The example catalog: 75 raylib demos in jolt
 
 A map of the whole suite. Each example is one namespace under
 `src/net/b12n/raylib_jlt/`, runnable by a friendly `bb <name>` task or the underlying
@@ -18,10 +18,10 @@ bb run-all [secs]  # every example, N seconds each (unattended)
 
 | preview | `bb` name | shows |
 |---|---|---|
-| [<img src="../demos/asteroids.gif" width="80">](demos.md#asteroids) | `asteroids` | the classic vector shooter — rotate / thrust / fire, splitting asteroids |
+| [<img src="../demos/asteroids.gif" width="80">](demos.md#asteroids) | `asteroids` | the classic vector shooter: rotate / thrust / fire, splitting asteroids |
 | [<img src="../demos/tetris.gif" width="80">](demos.md#tetris) | `tetris` | 10×20 well, 7 tetrominoes, rotation, line-clearing, levels |
 | [<img src="../demos/pong.gif" width="80">](demos.md#pong) | `pong` | two-paddle classic, you (W/S) vs a ball-tracking CPU |
-| [<img src="../demos/vampire-survivors.gif" width="80">](demos.md#vampire-survivors) | `vampire-survivors` | auto-firing survivors-like — chasing waves, XP gems, leveling |
+| [<img src="../demos/vampire-survivors.gif" width="80">](demos.md#vampire-survivors) | `vampire-survivors` | auto-firing survivors-like: chasing waves, XP gems, leveling |
 | [<img src="../demos/snake.gif" width="80">](demos.md#snake) | `snake` | the classic snake (arrow keys, grow, don't crash) |
 | [<img src="../demos/breakout.gif" width="80">](demos.md#breakout) | `breakout` | paddle + ball + brick grid (mouse paddle) |
 | [<img src="../demos/space-invaders.gif" width="80">](demos.md#space-invaders) | `space-invaders` | marching aliens (arrows + SPACE to shoot) |
@@ -37,7 +37,7 @@ bb run-all [secs]  # every example, N seconds each (unattended)
 | [<img src="../demos/input-keys.gif" width="80">](demos.md#input-keys) | `input-keys` | `IsKeyDown`, steer a ball with the arrow keys |
 | [<img src="../demos/input-mouse.gif" width="80">](demos.md#input-mouse) | `input-mouse` | `GetMouseX/Y`, `IsMouseButtonDown`, click to recolor |
 | [<img src="../demos/input-mouse-wheel.gif" width="80">](demos.md#input-mouse-wheel) | `input-mouse-wheel` | `GetMouseWheelMove` (a float return) scrolls a box |
-| [<img src="../demos/camera-2d.gif" width="80">](demos.md#camera-2d) | `camera-2d` | a 2D camera over a skyline — struct-by-value (see below) |
+| [<img src="../demos/camera-2d.gif" width="80">](demos.md#camera-2d) | `camera-2d` | a 2D camera over a skyline, struct-by-value (see below) |
 | [<img src="../demos/delta-time.gif" width="80">](demos.md#delta-time) | `delta-time` | per-frame vs `GetFrameTime` movement |
 | [<img src="../demos/scissor-test.gif" width="80">](demos.md#scissor-test) | `scissor-test` | `BeginScissorMode` clips a grid |
 | [<img src="../demos/basic-screen-manager.gif" width="80">](demos.md#basic-screen-manager) | `basic-screen-manager` | a LOGO / TITLE / GAMEPLAY / ENDING state flow |
@@ -94,7 +94,7 @@ bb run-all [secs]  # every example, N seconds each (unattended)
 
 | preview | `bb` name | shows |
 |---|---|---|
-| [<img src="../demos/camera-3d.gif" width="80">](demos.md#camera-3d) | `camera-3d` | an orbiting 3D camera — `Camera3D` by value + rlgl cube |
+| [<img src="../demos/camera-3d.gif" width="80">](demos.md#camera-3d) | `camera-3d` | an orbiting 3D camera, `Camera3D` by value + rlgl cube |
 | [<img src="../demos/waving-cubes.gif" width="80">](demos.md#waving-cubes) | `waving-cubes` | 196 cubes rippling in 3D (shared `rl/cube!`) |
 | [<img src="../demos/camera-3d-first-person.gif" width="80">](demos.md#camera-3d-first-person) | `camera-3d-first-person` | WASD + mouse-look walk through columns |
 | [<img src="../demos/tesseract-view.gif" width="80">](demos.md#tesseract-view) | `tesseract-view` | a rotating 4D hypercube projected 4D→3D→2D |
@@ -124,23 +124,23 @@ The 3D set stands entirely on two building blocks from
 | [<img src="../demos/l-system.gif" width="80">](demos.md#l-system) | `l-system` | an L-system fractal plant (grows + regrows) |
 | [<img src="../demos/flow-field.gif" width="80">](demos.md#flow-field) | `flow-field` | particles steered by a flow field (trails) |
 
-All seven are pure math + the drawing API — no new bindings. They showcase the
+All seven are pure math + the drawing API, no new bindings. They showcase the
 suite as a generative-art canvas: cellular automata, agent flocking, particle
 systems, rotating-vector Fourier series, parametric roulette curves, string-rewrite
 fractals, and noise-steered flow fields.
 
-## Adding an example — the four touchpoints
+## Adding an example: the four touchpoints
 
 The suite is deliberately mechanical to grow. One new example touches four places:
 
-1. **Source** — `src/net/b12n/raylib_jlt/<name>.clj`, a namespace with a `-main` that
+1. **Source**: `src/net/b12n/raylib_jlt/<name>.clj`, a namespace with a `-main` that
    runs the canonical loop (see [`headless-smoke-testing.md`](headless-smoke-testing.md))
    against the `net.b12n.raylib-jlt.raylib` API.
-2. **`deps.edn` alias** — `:<name> {:main-opts ["-m" "net.b12n.raylib-jlt.<name>"]}` so
+2. **`deps.edn` alias**: `:<name> {:main-opts ["-m" "net.b12n.raylib-jlt.<name>"]}` so
    `jolt -M:<name>` works.
-3. **`check.clj` require** — add `net.b12n.raylib-jlt.<name>` to the `:require` list in
+3. **`check.clj` require**: add `net.b12n.raylib-jlt.<name>` to the `:require` list in
    `net.b12n.raylib-jlt.check`, so the headless compile-check covers it.
-4. **`bb.edn` registry row** — add `["<display-name>" "<alias>" "<group>" "<desc>"]`
+4. **`bb.edn` registry row**: add `["<display-name>" "<alias>" "<group>" "<desc>"]`
    to the `examples` vector and a matching `bb <name>` task, so it shows in
    `bb info` / `bb examples` / `bb run-all`.
 
@@ -152,11 +152,11 @@ flowchart LR
 ```
 
 Filenames use underscores (`basic_screen_manager.clj`); the namespace uses hyphens
-(`net.b12n.raylib-jlt.basic-screen-manager`) — Clojure's standard file↔ns mapping.
+(`net.b12n.raylib-jlt.basic-screen-manager`), Clojure's standard file↔ns mapping.
 
 One ordering rule applies inside every file: since **jolt 0.4.0** an unresolved
 symbol is a compile error rather than a late-bound reference, so a definition must
-appear before its first use — in a fn body and in an `:or` destructuring default
+appear before its first use, in a fn body and in an `:or` destructuring default
 just as much as at top level. It bites hardest in the shared `raylib.clj` binding
 layer, where one misordered symbol stops *every* example from loading and only the
 first offender is reported. `jolt -M:check` is the quick confirmation; see the
@@ -164,7 +164,7 @@ first offender is reported. `jolt -M:check` is the quick confirmation; see the
 
 ## See also
 
-- [`kwarg-drawing-api.md`](kwarg-drawing-api.md) — the API every example is written
+- [`kwarg-drawing-api.md`](kwarg-drawing-api.md): the API every example is written
   against.
-- [`headless-smoke-testing.md`](headless-smoke-testing.md) — the loop shape and how
+- [`headless-smoke-testing.md`](headless-smoke-testing.md): the loop shape and how
   `bb run-all` / `bb check` verify the catalog.

--- a/docs/guide/headless-smoke-testing.md
+++ b/docs/guide/headless-smoke-testing.md
@@ -1,9 +1,9 @@
-# Headless smoke testing — proving a window rendered with no one watching
+# Headless smoke testing: proving a window rendered with no one watching
 
 A raylib example opens a window and runs until you close it. That's fine for a human,
 useless for CI or an agent: nothing here can click a close button, and a test that
 blocks forever is worse than no test. Two environment variables turn every windowed
-example into something a machine can drive and verify — without changing a line of
+example into something a machine can drive and verify, without changing a line of
 the example itself.
 
 ## The two knobs
@@ -11,9 +11,9 @@ the example itself.
 Both are read in `net.b12n.raylib-jlt.raylib` and consumed by the shared loop guards, so
 every example inherits them for free.
 
-- **`RAYLIB_APP_AUTO_QUIT_MS=<n>`** — close the window after `n` milliseconds. The
+- **`RAYLIB_APP_AUTO_QUIT_MS=<n>`**: close the window after `n` milliseconds. The
   example runs, renders real frames, then exits on its own.
-- **`RAYLIB_APP_SHOT=<name>`** — dump one frame to a PNG. Headless *visual* proof
+- **`RAYLIB_APP_SHOT=<name>`**: dump one frame to a PNG. Headless *visual* proof
   that a frame actually rendered, not just that the process didn't crash.
 
 ## Auto-quit: a deadline the loop checks
@@ -35,7 +35,7 @@ every example inherits them for free.
 ```
 
 With the var unset, `deadline` is `nil` and `keep-running?` reduces to "while the
-window is open" — normal interactive behavior. Set it, and the loop ends on its own.
+window is open", normal interactive behavior. Set it, and the loop ends on its own.
 
 ## The canonical loop
 
@@ -58,11 +58,11 @@ Every example is the same shape (`net.b12n.raylib-jlt.core`, the basic window):
 ```
 
 `frame` is threaded through the loop so `maybe-screenshot!` can fire on a specific
-frame (here frame 10 — a few frames in, so the first render has settled).
+frame (here frame 10, a few frames in, so the first render has settled).
 
 ## Screenshot: flush the batch first, or you get an empty PNG
 
-The subtle part. raylib **batches** geometry — `DrawText`, shapes, everything — and
+The subtle part. raylib **batches** geometry (`DrawText`, shapes, everything) and
 doesn't actually submit it to the framebuffer until `EndDrawing`. A naive
 `TakeScreenshot` mid-frame would capture the framebuffer *before* this frame's
 geometry lands, producing a blank or stale image. `maybe-screenshot!` flushes the
@@ -71,12 +71,12 @@ active render batch first:
 ```clojure
 (defn maybe-screenshot! [frame at]
   (when (and shot-path (= frame at))
-    (flush-batch)                 ; rlDrawRenderBatchActive — submit deferred geometry
+    (flush-batch)                 ; rlDrawRenderBatchActive, submit deferred geometry
     (take-screenshot shot-path)
     (binding [*out* *err*] (println "[net.b12n.raylib-jlt] SHOT" shot-path))))
 ```
 
-Note: raylib writes the file's **basename into the current working directory** — it
+Note: raylib writes the file's **basename into the current working directory**, it
 ignores any directory component of the path. So `RAYLIB_APP_SHOT=out/x.png` still
 writes `x.png` in CWD. Plan for that when collecting artifacts.
 
@@ -96,14 +96,14 @@ RAYLIB_APP_AUTO_QUIT_MS=2000 RAYLIB_APP_SHOT=shot.png jolt -M:run
 # opens, renders ~2s, writes shot.png, exits
 ```
 
-The whole suite as a demo reel / smoke test — `bb run-all` sets
+The whole suite as a demo reel / smoke test: `bb run-all` sets
 `RAYLIB_APP_AUTO_QUIT_MS` per example so each runs N seconds then advances:
 
 ```sh
 bb run-all 3     # every example, 3s each, unattended
 ```
 
-And the display-free check that belongs in CI — it compiles every example namespace
+And the display-free check that belongs in CI: it compiles every example namespace
 without opening a window at all:
 
 ```sh
@@ -113,7 +113,7 @@ bb check         # same, via babashka
 
 ## One environment caveat
 
-The screenshot path needs an **active display** — raylib/GLFW initializes a real GL
+The screenshot path needs an **active display**: raylib/GLFW initializes a real GL
 context. On a Mac whose display has slept, window creation can fail with "Failed to
 determine Monitor" and then crash. `jolt -M:check` needs no display and always
 works; `RAYLIB_APP_SHOT` needs a live (awake) display.
@@ -131,6 +131,6 @@ predicates mask before testing so a dirty high byte can't read as "true":
 
 ## See also
 
-- [`example-catalog.md`](example-catalog.md) — every example inherits these guards
+- [`example-catalog.md`](example-catalog.md): every example inherits these guards
   through the shared loop shape.
-- [`kwarg-drawing-api.md`](kwarg-drawing-api.md) — the `rl/*!` calls inside the loop.
+- [`kwarg-drawing-api.md`](kwarg-drawing-api.md): the `rl/*!` calls inside the loop.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,4 +1,4 @@
-# b12n-raylib-jlt — Guide
+# b12n-raylib-jlt Guide
 
 User-facing documentation for `b12n-raylib-jlt`: a suite of **[raylib](https://github.com/raysan5/raylib)
 examples written in [jolt](https://github.com/jolt-lang)** (native Clojure on Chez
@@ -9,62 +9,62 @@ convention, with citations to the source files that implement it.
 
 The examples show you *what* the suite draws; these pages explain *why* the binding
 layer is shaped the way it is. Almost every non-obvious decision in
-`net.b12n.raylib-jlt.raylib` traces back to one question — how a given C struct
-crosses the FFI boundary — and the answer differs per struct. Read these when you
+`net.b12n.raylib-jlt.raylib` traces back to one question (how a given C struct
+crosses the FFI boundary), and the answer differs per struct. Read these when you
 want to bind a C library from Jolt yourself, or when an example does something that
 looks needlessly indirect and you want the ABI reason behind it.
 
 ## What b12n-raylib-jlt is
 
-A community suite of 75 raylib examples — the classic core/shapes/text demos, a
+A community suite of 75 raylib examples: the classic core/shapes/text demos, a
 handful of games (asteroids, tetris, pong, vampire-survivors), and a 3D set
-(orbiting cameras, waving cubes, an rlgl solar system) — each a small Clojure
+(orbiting cameras, waving cubes, an rlgl solar system), each a small Clojure
 namespace on top of one shared binding layer, `net.b12n.raylib-jlt.raylib`.
 
 It is the **graphics sibling** of `b12n-tsj` (tree-sitter from Jolt, not yet
 public). Both bind a real external C library directly over its C ABI with
-`jolt.ffi` — Chez `foreign-procedure` under the hood. They differ on how hard the
+`jolt.ffi`, Chez `foreign-procedure` under the hood. They differ on how hard the
 library leans on **by-value structs**, and that difference is the whole story of the
 FFI pages here:
 
-> **raylib hits the *mild* version of struct-by-value — its hot path is `Color`,
+> **raylib hits the *mild* version of struct-by-value: its hot path is `Color`,
 > a 4-byte struct that reduces to a `uint32`, and its only large structs
 > (`Camera2D`/`Camera3D`) are by-value *arguments* it can fake behind a pointer on
-> AArch64. tree-sitter hits the *severe* version — a 32-byte `TSNode` passed AND
-> returned by value — so it needs a full C shim. raylib needs none.**
+> AArch64. tree-sitter hits the *severe* version: a 32-byte `TSNode` passed AND
+> returned by value, so it needs a full C shim. raylib needs none.**
 
 Three ABI facts drive every distinctive decision in this repo:
 
-1. **`Color` packs into a `:uint`** — a 4-byte all-integer struct travels in one
+1. **`Color` packs into a `:uint`**: a 4-byte all-integer struct travels in one
    general-purpose register, so every draw call passes color as an int, no struct
    marshaling. ([`color-by-value.md`](color-by-value.md))
-2. **`Camera2D`/`Camera3D` go by pointer** — a >16-byte composite is passed
+2. **`Camera2D`/`Camera3D` go by pointer**: a >16-byte composite is passed
    indirectly on AArch64, so a `[:pointer]` binding + a hand-built native struct
    works (with an x86-64 caveat). ([`struct-by-value-pointer-trick.md`](struct-by-value-pointer-trick.md))
-3. **`Vector2`/`Vector3` geometry uses rlgl** — small float structs go in FP
+3. **`Vector2`/`Vector3` geometry uses rlgl**: small float structs go in FP
    registers, which the pointer trick does *not* cover, so shapes and 3D cubes are
    drawn with rlgl's scalar immediate mode instead.
    ([`rlgl-immediate-mode.md`](rlgl-immediate-mode.md))
 
 Nothing about `jolt.ffi` is raylib-specific: it binds any C ABI symbol. The
 `analog-clock` / `digital-clock` examples call plain **libc** `time()`/`localtime()`
-(via `rl/local-time`) for real wall-clock time — the repo's one non-raylib FFI, reading
+(via `rl/local-time`) for real wall-clock time, the repo's one non-raylib FFI, reading
 `struct tm`'s `tm_hour`/`tm_min`/`tm_sec` ints straight out of native memory.
 
 ## Capability pages
 
 ### The FFI core (the reason this repo is interesting)
 
-- ✅ [`color-by-value.md`](color-by-value.md) — why raylib's `Color` crosses the
+- ✅ [`color-by-value.md`](color-by-value.md): why raylib's `Color` crosses the
   FFI boundary as a packed `:uint` and not a struct, the little-endian `rgba`
   packing, and the two-by-value-Colors-in-one-call case (`DrawRectangleGradientV`).
   Source: `src/net/b12n/raylib_jlt/raylib.clj` (`rgba`, `clear-background`, the palette).
-- ✅ [`struct-by-value-pointer-trick.md`](struct-by-value-pointer-trick.md) — how a
+- ✅ [`struct-by-value-pointer-trick.md`](struct-by-value-pointer-trick.md): how a
   24-byte `Camera2D` / 44-byte `Camera3D` is passed by value on AArch64 by
   allocating the struct in native memory and binding `BeginMode2D`/`BeginMode3D` as
   `[:pointer]`. **The x86-64 non-portability caveat is here.** Source:
   `raylib.clj` (`with-camera-2d`, `with-camera-3d`).
-- ✅ [`rlgl-immediate-mode.md`](rlgl-immediate-mode.md) — the fallback for by-value
+- ✅ [`rlgl-immediate-mode.md`](rlgl-immediate-mode.md): the fallback for by-value
   `Vector2`/`Vector3` args the pointer trick can't fake: rlgl scalar immediate mode
   (`rlBegin`/`rlVertex2f`/`rlVertex3f`/`rlColor4ub`) for the 2D triangle and the 3D
   `cube!`, plus the rlgl matrix stack for nested transforms (the solar-system demo).
@@ -72,14 +72,14 @@ Nothing about `jolt.ffi` is raylib-specific: it binds any C ABI symbol. The
 
 ### The drawing API
 
-- ✅ [`kwarg-drawing-api.md`](kwarg-drawing-api.md) — the two-layer design: raw
+- ✅ [`kwarg-drawing-api.md`](kwarg-drawing-api.md): the two-layer design: raw
   positional `ffi/defcfn` binds at the boundary (mirroring C), ergonomic
   keyword-argument wrappers (`text!`/`rect!`/`circle!`/…) on top, and the
   ">3 arguments → keyword args" style convention. Source: `raylib.clj`.
 
 ### Verifying without a display
 
-- ✅ [`headless-smoke-testing.md`](headless-smoke-testing.md) — how a windowed
+- ✅ [`headless-smoke-testing.md`](headless-smoke-testing.md): how a windowed
   example proves itself with no person at the keyboard: `RAYLIB_APP_AUTO_QUIT_MS`
   (auto-close), `RAYLIB_APP_SHOT` (dump one PNG), and the batched-geometry flush
   that makes the screenshot non-empty. Source: `raylib.clj` (`auto-quit-deadline`,
@@ -87,19 +87,19 @@ Nothing about `jolt.ffi` is raylib-specific: it binds any C ABI symbol. The
 
 ### Orientation
 
-- ✅ [`example-catalog.md`](example-catalog.md) — a tour of all 75 examples grouped
+- ✅ [`example-catalog.md`](example-catalog.md): a tour of all 75 examples grouped
   games / core / shapes / text / 3d / generative, what each demonstrates, and the four-touchpoint
   recipe for adding one (source ns + `deps.edn` alias + `check.clj` require +
   `bb.edn` registry row). Read this for the map; the FFI pages for the mechanics.
 
 ## See also
 
-- [raylib](https://github.com/raysan5/raylib) — the upstream C library, and the
+- [raylib](https://github.com/raysan5/raylib): the upstream C library, and the
   source of most examples here. Its own `examples/` tree is the reference these
   ports are named after.
-- [jolt](https://github.com/jolt-lang) — the native Clojure implementation whose
+- [jolt](https://github.com/jolt-lang): the native Clojure implementation whose
   `jolt.ffi` does all the binding work described on these pages.
-- `b12n-tsj` (not yet public) — the Jolt sibling that binds a by-value-*returning*
+- `b12n-tsj` (not yet public): the Jolt sibling that binds a by-value-*returning*
   C API (tree-sitter) and therefore needs a full C shim this repo avoids.
   [`struct-by-value-pointer-trick.md`](struct-by-value-pointer-trick.md) is the
   delta between "fake it with a pointer" (raylib arguments) and "you can't, write a

--- a/docs/guide/kwarg-drawing-api.md
+++ b/docs/guide/kwarg-drawing-api.md
@@ -8,11 +8,11 @@ This repo keeps the raw binds positional (they mirror C) and layers an ergonomic
 
 ## Two layers, one boundary
 
-The FFI boundary stays a faithful, positional mirror of the C signature — that's the
+The FFI boundary stays a faithful, positional mirror of the C signature: that's the
 contract with the library and the thing to check against `raylib.h`:
 
 ```clojure
-;; src/net/b12n/raylib_jlt/raylib.clj — the FFI boundary (positional, mirrors C)
+;; src/net/b12n/raylib_jlt/raylib.clj, the FFI boundary (positional, mirrors C)
 (ffi/defcfn draw-text      "DrawText"      [:string :int :int :int :uint] :void)
 (ffi/defcfn draw-rectangle "DrawRectangle" [:int :int :int :int :uint] :void)
 (ffi/defcfn draw-circle    "DrawCircle"    [:int :int :float :uint] :void)
@@ -37,7 +37,7 @@ On top sits a thin wrapper per call that names the arguments and supplies defaul
   (draw-circle x y (double radius) color))
 ```
 
-The wrappers also absorb small coercions the raw bind is strict about — e.g.
+The wrappers also absorb small coercions the raw bind is strict about, e.g.
 `circle!` calls `(double radius)` so a caller can pass an int radius without a type
 error at the `:float` boundary.
 
@@ -52,18 +52,18 @@ The payoff at the call site (`net.b12n.raylib-jlt.core`):
 The `!` suffix marks these as side-effecting calls. Sixteen wrappers exist, in three
 groups:
 
-- **Window + 2D primitives, straight over a scalar bind** — `window!`, `text!`,
+- **Window + 2D primitives, straight over a scalar bind**: `window!`, `text!`,
   `fps!`, `rect!`, `rect-lines!`, `rect-gradient!`, `circle!`, `circle-lines!`,
   `ellipse!`, `line!`, `pixel!`.
-- **2D shapes rlgl has to draw** — `sector!`, `ring!`, `line-ex!`. Their raylib
+- **2D shapes rlgl has to draw**: `sector!`, `ring!`, `line-ex!`. Their raylib
   originals (`DrawCircleSector`, `DrawRing`, `DrawLineEx`) take a `Vector2` by
   value and are unbindable, so these emit triangles instead. Same keyword-arg
   surface; see [`rlgl-immediate-mode.md`](rlgl-immediate-mode.md).
-- **3D** — `cube!` and `sphere!`, likewise rlgl vertex streams standing in for the
+- **3D**: `cube!` and `sphere!`, likewise rlgl vertex streams standing in for the
   by-value-`Vector3` `DrawCube` / `DrawSphere`.
 
 (`rl-color!` and `maybe-screenshot!` also end in `!` but are not part of this
-wrapper layer — one unpacks a `Color` for rlgl, the other is smoke-test plumbing.)
+wrapper layer, one unpacks a `Color` for rlgl, the other is smoke-test plumbing.)
 
 ## The style convention: >3 arguments → keyword args
 
@@ -85,7 +85,7 @@ themselves grouped `[x y z]` vectors so each stays one argument:
 (rl/cube! :pos [x 0 z] :size 0.8 :color rl/BLUE)
 ```
 
-The camera wrappers take a single map argument for the same reason — a `Camera2D`
+The camera wrappers take a single map argument for the same reason: a `Camera2D`
 has six scalars, well past three:
 
 ```clojure
@@ -95,7 +95,7 @@ has six scalars, well past three:
 
 ## Why not just bind everything keyword?
 
-Because the FFI boundary should stay a **1:1, positional mirror of the C signature** —
+Because the FFI boundary should stay a **1:1, positional mirror of the C signature**:
 that's what you diff against the header when a call misbehaves, and what keeps the
 "is this binding correct?" question answerable. Keyword ergonomics are a *caller*
 concern, so they live in a caller-facing layer above the boundary, never in the
@@ -104,9 +104,9 @@ the raw `:uint`/`rlColor4ub` binds rather than replacing them.
 
 ## See also
 
-- [`color-by-value.md`](color-by-value.md) — the packed-`Color` `:uint` the draw
+- [`color-by-value.md`](color-by-value.md): the packed-`Color` `:uint` the draw
   wrappers pass through unchanged.
-- [`rlgl-immediate-mode.md`](rlgl-immediate-mode.md) — `cube!` is the keyword-arg
+- [`rlgl-immediate-mode.md`](rlgl-immediate-mode.md): `cube!` is the keyword-arg
   wrapper over the positional `rl-vertex-3f` stream.
-- [`example-catalog.md`](example-catalog.md) — every example is written against this
+- [`example-catalog.md`](example-catalog.md): every example is written against this
   wrapper API.

--- a/docs/guide/rlgl-immediate-mode.md
+++ b/docs/guide/rlgl-immediate-mode.md
@@ -1,19 +1,19 @@
-# rlgl immediate mode — for the by-value float structs the pointer trick can't fake
+# rlgl immediate mode: for the by-value float structs the pointer trick can't fake
 
 Some raylib calls take a `Vector2` or `Vector3` **by value**: `DrawTriangle(Vector2,
 Vector2, Vector2, Color)`, `DrawCube(Vector3, …)`, `DrawSphere(Vector3, …)`. These
 are the one FFI case that neither [`color-by-value.md`](color-by-value.md) (packed
 `:uint`) nor [`struct-by-value-pointer-trick.md`](struct-by-value-pointer-trick.md)
-(pointer for >16 bytes) can handle. The way out is to not call them at all — draw the
+(pointer for >16 bytes) can handle. The way out is to not call them at all: draw the
 same geometry with rlgl's **scalar** immediate mode.
 
 ## Why the earlier tricks don't apply
 
 A `Vector2` is 8 bytes of two floats; a `Vector3` is 12 bytes of three floats. Both
 are **≤16-byte homogeneous float aggregates (HFAs)**, and the AArch64 ABI passes
-those in **floating-point registers**, one field per register — *not* as an integer
+those in **floating-point registers**, one field per register, *not* as an integer
 (so the `Color` `:uint` trick is out) and *not* indirectly through a pointer (so the
-`Camera2D` `[:pointer]` trick is out — that only applies to composites **larger**
+`Camera2D` `[:pointer]` trick is out; that only applies to composites **larger**
 than 16 bytes). There is no scalar or pointer binding that reproduces "three floats
 in three FP registers." So these functions are simply unbindable from Jolt.
 
@@ -42,7 +42,7 @@ unpacks the shared packed `Color` into the four `u8` args.
 ## 3D: `cube!` is 12 rlgl triangles
 
 The same move scales to 3D. `with-camera-3d` gets the camera active (via the pointer
-trick), but `DrawCube` takes a `Vector3` by value — unbindable — so `cube!` builds a
+trick), but `DrawCube` takes a `Vector3` by value (unbindable), so `cube!` builds a
 box out of `rl-vertex-3f`. Each face is a quad = two triangles, and faces are shaded
 by darkening the packed color so the cube reads as 3D without a lighting pass:
 
@@ -66,16 +66,16 @@ by darkening the packed color so the cube reads as 3D without a lighting pass:
 stands on (`camera-3d`, `waving-cubes`, `box-collisions`, …). `DrawGrid` is scalar
 (`[:int :float]`) so it's bound and used directly.
 
-`sphere!` is the same idea for a ball — lat/long rings of `RL_TRIANGLES`, faces
-shaded by latitude (brighter toward +y) — and drives the `bouncing-spheres` example.
+`sphere!` is the same idea for a ball, lat/long rings of `RL_TRIANGLES` with faces
+shaded by latitude (brighter toward +y), and drives the `bouncing-spheres` example.
 `DrawSphere` takes a `Vector3` by value too, so it gets the same rlgl treatment as
 the cube.
 
-## The rlgl matrix stack — nested transforms for free
+## The rlgl matrix stack: nested transforms for free
 
 rlgl also exposes its transform stack, and it applies the **current** transform to
 each `rlVertex*` at **submit time**. So wrapping push/rotate/translate/scale around a
-`cube!` call moves that cube — the same nested-transform model as `BeginMode2D`, but
+`cube!` call moves that cube, the same nested-transform model as `BeginMode2D`, but
 in scalars:
 
 ```clojure
@@ -98,7 +98,7 @@ flowchart TD
 ```
 
 The `rlgl-solar-system` example (`net.b12n.raylib-jlt.rlgl-solar-system`) uses exactly
-this to make Earth orbit the Sun and the Moon orbit Earth — nested push/translate/
+this to make Earth orbit the Sun and the Moon orbit Earth: nested push/translate/
 rotate around three `cube!` calls, no matrix math in Clojure. It's also the
 **portable** substitute for the AArch64-only camera pointer trick (see the x86-64
 caveat in [`struct-by-value-pointer-trick.md`](struct-by-value-pointer-trick.md)).
@@ -107,7 +107,7 @@ caveat in [`struct-by-value-pointer-trick.md`](struct-by-value-pointer-trick.md)
 
 The same wall stops `DrawCircleSector` / `DrawRing` / `DrawCircleV`: they take a
 `Vector2` center **by value** (a float pair in FP registers), so they're unbindable by
-the pointer trick. The fix is the same — draw the arc as an rlgl triangle fan.
+the pointer trick. The fix is the same: draw the arc as an rlgl triangle fan.
 `sector!` (in `raylib.clj`) builds one:
 
 ```clojure
@@ -117,27 +117,27 @@ the pointer trick. The fix is the same — draw the arc as an rlgl triangle fan.
 
 Each sub-triangle is emitted `rim → center → rim` with the angle **increasing**
 (`rim = (sin θ, -cos θ)`, so 0° points up and grows clockwise). That order carries
-raylib's **front-facing winding** — a fan wound the other way is silently
+raylib's **front-facing winding**: a fan wound the other way is silently
 backface-culled (raylib enables `GL_CULL_FACE`). Two examples consume it:
 `pie-chart` (one fan per slice) and `vector-angle` (a translucent fan for the measured
 angle). `color-wheel` draws its own fan directly because it needs a *per-vertex* hue
 (a different `rl-color!` before each rim vertex), which a single-color helper can't
 express. The showpiece `penrose-tiling` fills ~900 deflation triangles of *mixed*
 winding, so it normalizes each to negative signed area (the proven front face) before
-the batch — the general form of the winding rule `sector!` bakes in.
+the batch, the general form of the winding rule `sector!` bakes in.
 
 ## 2D: `ring!` and `line-ex!`
 
 Two more by-value casualties get the same rlgl treatment:
 
-- **`ring!`** — a filled annulus (donut sector), the stand-in for `DrawRing`. Instead
+- **`ring!`**: a filled annulus (donut sector), the stand-in for `DrawRing`. Instead
   of a center-anchored fan it walks a **quad strip** between an inner and an outer
   radius: each angular step emits two triangles spanning `inner → outer` across `dθ`,
   wound front-facing. `analog-clock`'s bezel and `ring-drawing` use it.
-- **`line-ex!`** — a thick line, the stand-in for `DrawLineEx` (both `Vector2`
+- **`line-ex!`**: a thick line, the stand-in for `DrawLineEx` (both `Vector2`
   endpoints by value). It offsets the two endpoints by `±thick/2` along the unit
   perpendicular `(dy,-dx)/len` and fills the resulting quad as two triangles. That
-  perpendicular convention keeps the quad front-wound at **every** line direction — so
+  perpendicular convention keeps the quad front-wound at **every** line direction, so
   a rotating fan of them (`lines-drawing`) or a sweeping clock hand (`analog-clock`)
   never flips to a culled back face. `line-ex!` also draws the clock ticks and the
   `ring-drawing` outline stroke.
@@ -150,14 +150,14 @@ in `raylib.clj` beside the raw `rl-*` binds.
 When a C graphics API forces geometry through by-value small-float-vector arguments,
 look for a scalar immediate-mode or builder API on the same library and drive that
 instead of fighting the ABI. rlgl is raylib's; many GPU libraries ship an equivalent.
-The cost is you re-express shapes as vertex streams — cheap, and it keeps the whole
+The cost is you re-express shapes as vertex streams: cheap, and it keeps the whole
 FFI boundary scalar.
 
 ## See also
 
-- [`struct-by-value-pointer-trick.md`](struct-by-value-pointer-trick.md) — the
+- [`struct-by-value-pointer-trick.md`](struct-by-value-pointer-trick.md): the
   camera side (>16-byte structs) and why its matrix-op alternative lives here.
-- [`color-by-value.md`](color-by-value.md) — `rl-color!` shares the packed-`Color`
+- [`color-by-value.md`](color-by-value.md): `rl-color!` shares the packed-`Color`
   representation with the rest of the API.
-- [`kwarg-drawing-api.md`](kwarg-drawing-api.md) — `cube!` follows the keyword-arg
+- [`kwarg-drawing-api.md`](kwarg-drawing-api.md): `cube!` follows the keyword-arg
   convention; the raw `rl-*` binds stay positional.

--- a/docs/guide/struct-by-value-pointer-trick.md
+++ b/docs/guide/struct-by-value-pointer-trick.md
@@ -4,7 +4,7 @@ raylib's cameras are structs passed **by value**: `BeginMode2D(Camera2D)` takes 
 bytes, `BeginMode3D(Camera3D)` takes 44 bytes. Chez `foreign-procedure` (what
 `jolt.ffi/defcfn` lowers to) has no by-value-aggregate calling convention. Unlike
 `Color` (see [`color-by-value.md`](color-by-value.md)) these are far too big to fake
-as a register-width int. But on AArch64 there is still a way — and it comes straight
+as a register-width int. But on AArch64 there is still a way, and it comes straight
 out of the ABI.
 
 ## The ABI fact
@@ -23,7 +23,7 @@ void BeginMode2D(Camera2D camera);
 On the **AArch64** (Apple silicon) procedure-call standard, a composite larger than
 16 bytes is passed **indirectly**: the caller allocates the struct somewhere, and
 what actually goes in the argument register is a **pointer** to it. So at the machine
-level, `BeginMode2D(Camera2D)` and `BeginMode2D(Camera2D*)` are the *same call* — the
+level, `BeginMode2D(Camera2D)` and `BeginMode2D(Camera2D*)` are the *same call*: the
 callee receives a pointer either way.
 
 That means a Jolt binding can declare the parameter as `[:pointer]`, build the 24
@@ -71,7 +71,7 @@ flowchart LR
 
 ## Camera3D is the same recipe, bigger
 
-`Camera3D` is 44 bytes — three `Vector3` (position, target, up) + a `float fovy` +
+`Camera3D` is 44 bytes: three `Vector3` (position, target, up) + a `float fovy` +
 an `int projection`. `with-camera-3d` allocates 44 and writes nine floats then one
 int:
 
@@ -83,25 +83,25 @@ int:
   (begin-mode-3d-ptr p) (f) (end-mode-3d))
 ```
 
-Both wrappers use `try`/`finally` so the native buffer is freed even if `f` throws —
+Both wrappers use `try`/`finally` so the native buffer is freed even if `f` throws,
 the same discipline the sibling project applies to its node buffers.
 
-## The x86-64 caveat — this is **not** portable as written
+## The x86-64 caveat: this is **not** portable as written
 
 The trick works *because* AArch64 passes >16-byte structs indirectly. On the
 **x86-64 System V** ABI, those 24 bytes are classified and passed **on the stack**
-(in pieces), which a `[:pointer]` binding does **not** do — it would put a pointer
+(in pieces), which a `[:pointer]` binding does **not** do; it would put a pointer
 where the callee expects 24 bytes of struct data, and the call reads garbage
 (typically an "invalid memory reference" crash).
 
 So `camera2d`/`camera-3d` are AArch64-only as written. The **portable** alternative
 is to skip `BeginMode2D` entirely and apply the same transform with rlgl's scalar
-matrix ops (`rlPushMatrix`/`rlTranslatef`/`rlRotatef`/`rlScalef`) — which is exactly
+matrix ops (`rlPushMatrix`/`rlTranslatef`/`rlRotatef`/`rlScalef`), which is exactly
 what `BeginMode2D` does internally. See [`rlgl-immediate-mode.md`](rlgl-immediate-mode.md)
 for the matrix stack. The source flags this inline:
 
 ```clojure
-;; NOTE: this is AArch64-specific — on the x86-64 SysV ABI the 24 bytes are passed
+;; NOTE: this is AArch64-specific. On the x86-64 SysV ABI the 24 bytes are passed
 ;; on the stack, which a [:pointer] binding does NOT do (see README). For a portable
 ;; alternative, apply the same transform with the scalar rlgl matrix ops instead.
 ```
@@ -109,7 +109,7 @@ for the matrix stack. The source flags this inline:
 ## By-value **returns** are a different, harder problem
 
 This trick fakes a by-value struct **argument**. It does nothing for a function that
-**returns** a struct by value — on AArch64 that uses the `x8` sret register, which
+**returns** a struct by value: on AArch64 that uses the `x8` sret register, which
 Chez doesn't expose. raylib's hot path never needs a by-value struct return, so this
 repo never hits it. Its Jolt sibling `b12n-tsj` (not yet public) is not so lucky:
 tree-sitter's
@@ -122,14 +122,14 @@ a C shim. That contrast is the reason both projects exist side by side.
 For any Chez/Jolt FFI on AArch64 that needs to pass a >16-byte struct **by value**:
 allocate `sizeof(T)` with `ffi/alloc`, write each field at its C offset, bind the
 function as `[:pointer]`, and free in `finally`. Confirm `sizeof` and every offset
-against the C header. Do **not** assume it ports to x86-64 — reach for rlgl matrix
+against the C header. Do **not** assume it ports to x86-64; reach for rlgl matrix
 ops (or a real shim) there.
 
 ## See also
 
-- [`color-by-value.md`](color-by-value.md) — the small-struct case that fits in a
+- [`color-by-value.md`](color-by-value.md): the small-struct case that fits in a
   register and needs none of this.
-- [`rlgl-immediate-mode.md`](rlgl-immediate-mode.md) — the portable matrix-stack
+- [`rlgl-immediate-mode.md`](rlgl-immediate-mode.md): the portable matrix-stack
   alternative, and the fallback for by-value *float* structs (`Vector2`/`Vector3`).
-- `b12n-tsj` (not yet public) — the sibling case where the pointer trick isn't
+- `b12n-tsj` (not yet public): the sibling case where the pointer trick isn't
   enough (by-value returns) and you must write a C shim.


### PR DESCRIPTION
Same sweep as `b12n-raylib-jnk` #10, same house rule: **restructure the
sentence rather than swap the character.** A colon where what follows
explains what precedes, a semicolon between two independent clauses,
paired commas or parentheses for an aside, a full stop where the clause
stands alone. Definition-style list items and table cells take a colon.

173 instances across 11 files:

| file | n |
|---|---|
| `README.md` | 54 |
| `docs/guide/index.md` | 22 |
| `docs/guide/rlgl-immediate-mode.md` | 20 |
| `docs/guide/example-catalog.md` | 15 |
| `docs/guide/headless-smoke-testing.md` | 14 |
| `docs/guide/struct-by-value-pointer-trick.md` | 13 |
| `CONTRIBUTING.md` | 12 |
| `docs/guide/kwarg-drawing-api.md` | 12 |
| `docs/guide/color-by-value.md` | 6 |
| `docs/guide/demos.md` | 1 |
| `.github/pull_request_template.md` | 1 |

Six sat inside fenced code blocks, all in Clojure or shell comments, so
those took a comma or parentheses rather than a restructure.

## One anchor moved

The example catalog's heading `## Adding an example — the four
touchpoints` is now `## Adding an example: the four touchpoints`, so
`CONTRIBUTING.md`'s deep link is repointed:

```
#adding-an-example--the-four-touchpoints   ->   #adding-an-example-the-four-touchpoints
```

(the old anchor had a double hyphen, which is what GitHub's slugifier
produced from the em-dash).

## Verification

- 0 broken heading anchors and 0 broken relative `.md` links repo-wide
- pre-commit hooks green: `bb lint:strict`, `clojure-lsp format --dry`,
  `clojure-lsp clean-ns --dry`
- pure substitution: 170 insertions, 170 deletions, no content added or
  dropped

The published site picks this up on the next `bb docs-sync`.