### PR TITLE
Pin docs-engine v0.2.0, and check the mermaid gating

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -26,7 +26,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  DOCS_ENGINE_REF: v0.1.0
+  DOCS_ENGINE_REF: v0.2.0
   BASE_PATH: /raylib-jlt
 
 jobs:
@@ -76,6 +76,15 @@ jobs:
 
           grep -q 'pre class="mermaid"' "$out/guide/color-by-value.html" \
             || { echo "mermaid fences were not rewritten"; exit 1; }
+
+          # Since engine v0.2.0 the 3.4 MB bundle loads only where a diagram
+          # exists. Both directions matter: a page with a diagram that does not
+          # load it renders unstyled source text, and a page without one that
+          # does costs every reader 3.4 MB for nothing.
+          grep -q 'mermaid.min.js' "$out/guide/color-by-value.html" \
+            || { echo "a page with a diagram is not loading mermaid"; exit 1; }
+          ! grep -q 'mermaid.min.js' "$out/guide/demos.html" \
+            || { echo "a page with no diagram is loading mermaid"; exit 1; }
 
           # The failure mode this site's base path exists to prevent. Served at
           # jlt-commons.github.io/raylib-jlt/, a root-absolute URL loads the


### PR DESCRIPTION
Engine `v0.2.0` loads the 3.4 MB mermaid bundle only on pages that actually have
a diagram, instead of on every page.

Six of this site's eleven pages have one. The other five stop paying for it:

| loads mermaid | does not |
|---|---|
| homepage, color-by-value, example-catalog, headless-smoke-testing, rlgl-immediate-mode, struct-by-value-pointer-trick | demos, guide index, kwarg-drawing-api, textures-via-rlgl, 404 |

The gallery page is the one that mattered most — it is the heaviest page on the
site already, and it was pulling 3.4 MB it had no use for.

## Why the check goes both ways

Both directions fail quietly, which is the whole reason for a check rather than a
look:

- A page **with** a diagram that stops loading the bundle renders the diagram as
  unstyled source text. No error, just a wall of `flowchart LR` in a code block.
- A page **without** one that starts loading it costs every reader 3.4 MB and
  shows nothing.

So `color-by-value.html` must load it and `demos.html` must not. Verified locally
against a real build before pushing.