### PR TITLE
fix: rl/run! starts an example from a connected editor, and the homepage diagram fits its column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Examples read at <https://jlt-commons.github.io/raylib-jlt/>.
 
 ## Unreleased
 
+- **The site's diagrams fit the column they are drawn in.** The homepage's
+  "How it fits together" flowchart was laid out left to right and came out
+  1458px wide against a 1120px content column, so the browser scaled the whole
+  SVG down to fit and shrank the text with it: 77% at a 1440px window, about
+  half size at 768px, which is where it was reported as unreadable. Top-down
+  puts the same six nodes in 596px, inside the column at every width, so
+  nothing is scaled at all.
 - **`rl/run!` starts an example from a connected editor.** Evaluating `(-main)`
   over nREPL killed the whole jolt process on macOS, editor connection included,
   with no Clojure exception to explain it: raylib opens its window through GLFW,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Examples read at <https://jlt-commons.github.io/raylib-jlt/>.
 
 ## Unreleased
 
+- **`rl/run!` starts an example from a connected editor.** Evaluating `(-main)`
+  over nREPL killed the whole jolt process on macOS, editor connection included,
+  with no Clojure exception to explain it: raylib opens its window through GLFW,
+  macOS only lets AppKit initialize on the process main thread, and an nREPL eval
+  runs on a worker thread. `(rl/run! -main)` marshals onto the main thread that
+  `jolt nrepl-server` parks in its pump, and invokes inline when no pump is
+  running, so it is also correct under `bb <example>`. A running loop picks up
+  redefined vars, which makes this a real interactive loop and not just a
+  launcher. New guide page: `docs/guide/repl-driven-development.md`.
+
 - **Eighteen more examples, taking the suite to 115.** `clock-of-clocks`,
   `undo-redo`, `window-should-close`, `ellipse-collision`, `input-gestures`,
   `rlgl-triangle`, `random-sequence`, `camera-2d-mouse-zoom`,

--- a/README.md
+++ b/README.md
@@ -210,6 +210,20 @@ with `git commit --no-verify`.
 bb nrepl [port]  # start a jolt nREPL server for interactive dev (default 7888)
 ```
 
+Start an example from a connected editor with `rl/run!`, never a bare `(-main)`:
+
+```clojure
+(comment
+  (rl/run! -main))
+```
+
+raylib opens its window through GLFW, and macOS only lets AppKit initialize on the
+process main thread. An nREPL eval runs on a worker thread, so calling `-main`
+directly traps the whole jolt process, taking the editor connection with it.
+`rl/run!` hops onto the main thread, and runs inline (changing nothing) when there
+is no REPL. See
+[`docs/guide/repl-driven-development.md`](docs/guide/repl-driven-development.md).
+
 ### With jolt directly
 
 Each example is also a `jolt` alias:

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -100,6 +100,14 @@ Nothing about `jolt.ffi` is raylib-specific: it binds any C ABI symbol. The
   keyword-argument wrappers (`text!`/`rect!`/`circle!`/…) on top, and the
   ">3 arguments → keyword args" style convention. Source: `raylib.clj`.
 
+### Working from an editor
+
+- ✅ [`repl-driven-development.md`](repl-driven-development.md): why evaluating
+  `(-main)` over nREPL kills the whole process on macOS (AppKit only initializes
+  on the main thread, an nREPL eval does not run there), the `rl/run!` call that
+  fixes it, and what does and does not work against a running window. Source:
+  `raylib.clj` (`run!`).
+
 ### Verifying without a display
 
 - ✅ [`headless-smoke-testing.md`](headless-smoke-testing.md): how a windowed

--- a/docs/guide/repl-driven-development.md
+++ b/docs/guide/repl-driven-development.md
@@ -70,7 +70,7 @@ which doubles as a **main-thread pump**. `call-on-main-thread-async` enqueues th
 thunk onto that pump, so the window opens on the thread macOS insists on.
 
 ```mermaid
-flowchart LR
+flowchart TB
   ed["editor<br/>(rl/run! -main)"] --> w["nREPL worker thread"]
   w -->|"enqueue"| q["main-thread queue"]
   q --> m["primordial thread<br/>park-until-interrupt pump"]

--- a/docs/guide/repl-driven-development.md
+++ b/docs/guide/repl-driven-development.md
@@ -1,0 +1,156 @@
+# REPL-driven development: why `(-main)` kills your editor connection
+
+Connect an editor to `bb nrepl`, evaluate the buffer, then evaluate `(-main)` to see
+the window. On macOS the whole thing dies:
+
+```
+[nREPL] Connection closed unexpectedly (connection broken by remote peer)
+```
+
+No Clojure exception, no stack trace, nothing in the REPL buffer. The message is
+literal: the process on the other end stopped existing mid-sentence, so the socket
+went with it. This page explains why, and gives you the one call that fixes it.
+
+## The cause: raylib's window belongs to the main thread
+
+macOS only lets `NSApplication` initialize on the **process main thread**. An nREPL
+eval does not run there. The server accepts connections on a background thread and
+hands each evaluation to a worker, so `InitWindow` reaches AppKit from the wrong
+thread and AppKit traps the process outright.
+
+The crash report (`~/Library/Logs/DiagnosticReports/jolt-*.ips`) shows it exactly.
+Read it bottom-up:
+
+```
+AppKit                 NSUpdateCycleInitialize
+AppKit                 -[NSApplication run]
+libraylib.6.0.0.dylib  _glfwInitCocoa
+libraylib.6.0.0.dylib  glfwInit
+libraylib.6.0.0.dylib  InitPlatform
+libraylib.6.0.0.dylib  InitWindow
+jolt                   Scall0
+jolt                   start_thread          <-- a spawned thread, not the main one
+libsystem_pthread      _pthread_start
+```
+
+`EXC_BREAKPOINT (SIGTRAP)`. This is a trap inside AppKit, not a Clojure error, which
+is why nothing catches it and why the REPL has nothing to print. The last thing the
+server logs is raylib's own banner, stopping right where GLFW reaches Cocoa:
+
+```
+INFO: Initializing raylib 6.0
+INFO: Platform backend: DESKTOP (GLFW)
+INFO: Supported raylib modules:
+INFO:     > rcore:..... loaded (mandatory)
+...
+INFO:     > raudio:.... loaded (optional)
+                            <-- process gone
+```
+
+## The fix: `rl/run!`
+
+```clojure
+(comment
+  (rl/run! -main))
+```
+
+That is the whole change. Every example's `(comment ...)` block should start it this
+way rather than with a bare `(-main)`.
+
+`run!` hops the call onto the main thread:
+
+```clojure
+;; src/net/b12n/raylib_jlt/raylib.clj
+(defn run! [f]
+  (jolt.host/call-on-main-thread-async f))
+```
+
+Under `jolt nrepl-server` the primordial thread parks in `jolt.host/park-until-interrupt`,
+which doubles as a **main-thread pump**. `call-on-main-thread-async` enqueues the
+thunk onto that pump, so the window opens on the thread macOS insists on.
+
+```mermaid
+flowchart LR
+  ed["editor<br/>(rl/run! -main)"] --> w["nREPL worker thread"]
+  w -->|"enqueue"| q["main-thread queue"]
+  q --> m["primordial thread<br/>park-until-interrupt pump"]
+  m --> r["InitWindow → GLFW → AppKit ✓"]
+  w -.->|"direct (-main)"| x["InitWindow off-main<br/>EXC_BREAKPOINT ✗"]
+```
+
+The same call is correct outside the REPL. With no pump running, which is what
+`bb bounce` and `jolt -M:bounce` do, `call-on-main-thread-async` invokes the thunk
+**inline** on the caller's thread, which is already the main one. So wrapping an
+example's entry point costs nothing in the normal run path.
+
+## Blocking or not
+
+There are two variants and they differ only in who waits.
+
+| call | the eval returns | REPL while the window is open |
+| --- | --- | --- |
+| `rl/run!` (`call-on-main-thread-async`) | immediately | free |
+| `jolt.host/call-on-main-thread` | when the window closes | blocked until then |
+
+`rl/run!` uses the async one, because a render loop runs until you close the window
+and there is no reason to hold an editor connection hostage for that. Reach for the
+blocking form only when you want the eval's return value to mean "the window is
+closed", such as in a script.
+
+## What actually works while a window is up
+
+Measured on macOS 26 (Darwin 25.5), jolt 0.7.28, raylib 6.0, against `bounce`:
+
+- **The REPL keeps answering.** Evaluations return normally while the loop renders.
+- **The running loop picks up redefined vars.** Redefine a function the frame loop
+  calls, and the next frame calls the new one. A counter wired into a per-frame
+  function through a redefinition went 0 → 5 → 15 across three reads with the window
+  still open. This is ordinary var indirection: the loop resolves the var each
+  frame rather than capturing the function value once.
+
+That second point is the interesting one, because it is what makes this a real
+interactive loop rather than just a way to launch a window. Tweak a drawing function,
+re-evaluate it, watch the running window change.
+
+## What not to do from the REPL
+
+**Don't call raylib drawing, lifecycle, or resource functions directly from an
+evaluation.** Those belong to whichever thread owns the window. `rl/run!` exists to
+move *entry* onto that thread; it does not make every later `rl/circle!` safe to fire
+from a worker. Change what the loop draws by redefining the function it calls, and
+let the loop make the call.
+
+The same conclusion was reached independently on Linux, in
+[jasalt/raylib-jlt's nREPL report](https://github.com/jasalt/raylib-jlt/blob/main/nrepl-results/REPORT.md)
+(Fedora 44, jolt 0.7.27, raylib 6.0, under Xvfb): pure var redefinition is safe
+provided the render loop dereferences vars dynamically, while drawing and lifecycle
+calls must stay on a single owner thread, with anything else routed through an
+application-owned queue.
+
+The platforms differ in how loudly they say so. On macOS the very first `InitWindow`
+from a worker is fatal and immediate, because AppKit checks. Elsewhere the same rule
+holds but breaking it degrades rather than traps, which makes it easier to get away
+with by accident and harder to debug later. Write it the safe way on every platform.
+
+## Debugging the next one of these
+
+When a jolt REPL disappears with no Clojure stack trace, it is a native crash, not an
+evaluation error, and the evidence is outside the REPL:
+
+```sh
+# the crash report for the process that just vanished
+ls -t ~/Library/Logs/DiagnosticReports/jolt-*.ips | head -1
+```
+
+The frames at the bottom of the triggered thread tell you which thread you were on:
+`start_thread` means a spawned one, and anything touching AppKit from there is the
+bug. The server's own stdout is the other half, since it shows how far raylib got
+before the process died.
+
+## See also
+
+- [`headless-smoke-testing.md`](headless-smoke-testing.md): `RAYLIB_APP_AUTO_QUIT_MS`
+  closes the window on a timer, which is handy from the REPL too when you would
+  rather not reach for the mouse.
+- [`example-catalog.md`](example-catalog.md): every example shares the `-main` shape
+  that `rl/run!` starts.

--- a/docs/templates/home.html
+++ b/docs/templates/home.html
@@ -165,7 +165,7 @@
   <div class="inner">
     <h2>How it fits together</h2>
     <pre class="mermaid">
-flowchart LR
+flowchart TB
   subgraph ex["119 example namespaces"]
     e["pong · boids · tetris<br/>camera-3d · penrose-tiling · …"]
   end

--- a/src/net/b12n/raylib_jlt/bounce.clj
+++ b/src/net/b12n/raylib_jlt/bounce.clj
@@ -36,3 +36,10 @@
           (rl/end-drawing)
           (recur (inc frame) x y vx vy paused?)))))
   (rl/close-window))
+
+(comment
+  ;; Not (-main): over nREPL that opens the window from a worker thread and
+  ;; macOS kills the process. rl/run! hops onto the main thread.
+  (rl/run! -main)
+
+  nil)

--- a/src/net/b12n/raylib_jlt/raylib.clj
+++ b/src/net/b12n/raylib_jlt/raylib.clj
@@ -9,8 +9,12 @@
   only by-value struct that crosses the FFI boundary is `Color`, a 4-byte
   {u8 r,g,b,a} packed into a :uint (see `rgba` and README.md). The one exception,
   Camera2D (24 bytes, passed by pointer), lives in net.b12n.raylib-jlt.camera2d, not here."
+  ;; run! is the REPL entry point (see the bottom of this file); the shadowed
+  ;; clojure.core/run! is a reducing form this suite never uses.
+  (:refer-clojure :exclude [run!])
   (:require
-   [jolt.ffi :as ffi]))
+   [jolt.ffi :as ffi]
+   [jolt.host]))
 
 ;; --- Color -------------------------------------------------------------------
 ;; Defined first: every drawing binding below takes a packed Color :uint, and
@@ -1287,3 +1291,33 @@
       (ffi/write-field t texture2d-layout :mipmaps 1)
       (ffi/write-field t texture2d-layout :format PIXELFORMAT-R8G8B8A8)
       (set-shader-value-texture-raw sh loc t))))
+
+;; --- REPL entry point --------------------------------------------------------
+;; InitWindow reaches AppKit through GLFW, and macOS only lets NSApplication
+;; initialize on the process main thread. An nREPL eval runs on a worker thread,
+;; so calling an example's -main straight from a connected editor traps the whole
+;; process: EXC_BREAKPOINT inside -[NSApplication run], with no Clojure exception
+;; to catch and nothing in the REPL but a dropped connection.
+;;
+;; jolt.host/call-on-main-thread-async marshals the call onto the thread `jolt
+;; nrepl-server` parks in its main pump, and invokes it inline when no pump is
+;; running, which is what `bb <example>` does. So the one call is right from both.
+
+(defn run!
+  "Run an example's entry point `f` on the process main thread, the only thread
+  macOS lets raylib open a window from. This is how an example starts from a
+  connected editor:
+
+      (comment
+        (rl/run! -main))
+
+  Calling `(-main)` directly over nREPL instead kills the whole jolt process,
+  editor connection included, because the eval runs on a worker thread and macOS
+  traps any thread but the main one initializing AppKit.
+
+  Returns immediately under `jolt nrepl-server`: the window loop takes the main
+  thread and the REPL stays free. Under `bb <example>` there is no pump and the
+  caller is already the main thread, so `f` runs inline and this wrapper changes
+  nothing."
+  [f]
+  (jolt.host/call-on-main-thread-async f))


### PR DESCRIPTION
Evaluating `(-main)` from a connected editor killed the whole jolt process on
macOS, and the docs site's homepage diagram rendered too small to read. Two
reports, two commits.

## `rl/run!` (closes #7)

macOS only lets `NSApplication` initialize on the process main thread, and an
nREPL eval does not run there. So `InitWindow` reached AppKit from a worker
thread and AppKit trapped the process: `EXC_BREAKPOINT` inside
`-[NSApplication run]`, called from `glfwInit`, on a stack that bottoms out at
`start_thread`. No Clojure exception, nothing in the REPL but a dropped
connection, which left nothing to debug from.

jolt already ships the way out. Under `nrepl-server` the primordial thread parks
in `jolt.host/park-until-interrupt`, which doubles as a main-thread pump, so:

```clojure
(comment
  (rl/run! -main))
```

hands the entry point to `call-on-main-thread-async` and the window opens where
macOS insists. With no pump running, which is what `bb <example>` does, the same
call invokes inline on a caller that is already the main thread, so the normal
run path is untouched.

Measured on macOS 26, jolt 0.7.28, raylib 6.0, against `bounce`:

| | before | after |
| --- | --- | --- |
| `(-main)` over nREPL | process dies | n/a, use `rl/run!` |
| `(rl/run! -main)` | n/a | window opens and closes cleanly, server survives |
| REPL during render | n/a | keeps answering |
| redefining a per-frame var | n/a | picked up by the running loop |

That last row is what makes this an interactive loop rather than a launcher: a
counter wired into a per-frame function by redefinition read 0, then 5, then 15
across three evaluations with the window still open.

Drawing, lifecycle and resource calls still belong to the thread that owns the
window. `run!` moves entry onto that thread and nothing more, which the new page
says explicitly.

`run!` shadows `clojure.core/run!`, a reducing form this suite never uses, so the
ns carries `(:refer-clojure :exclude [run!])` matching the idiom `reasings.clj`
already uses. Without it `bb lint:strict` fails.

## The homepage diagram

Reported on Firefox and Chromium as "diagram is too small". Mermaid emits the
flowchart with `width:100%` and a viewBox, so an SVG wider than its container is
scaled down uniformly and the text shrinks with it. Nothing browser-specific
about it, just a chart drawn wider than the column.

Measured in headless Chromium against the built site:

| chart | natural | rendered @1440 |
| --- | --- | --- |
| homepage, `flowchart LR` | 1458x212 | 1118x163, 77% |
| homepage, `flowchart TB` | 596x674 | 596x674, 100% |
| nREPL page, `LR` | 1404x210 | scaled |
| nREPL page, `TB` | 500x606 | 500x606, 100% |

Both now render at natural size at 1440, 1024 and 768 alike, so nothing is
scaled at any width. `headless-smoke-testing`'s chart is 1058x94, already inside
the 1120px column, and is left alone.

## Docs

New `docs/guide/repl-driven-development.md` covers the crash, `rl/run!`, what
does and does not work against a running window, and how to read the `.ips`
crash report when a jolt REPL disappears with no stack trace. Linked from the
guide index under a new "Working from an editor" section, and from the README's
Dev section. The guide had nothing about REPL-driven development before, which
is part of why this was hard to diagnose.

The same conclusion was reached independently on Linux in
[jasalt/raylib-jlt's nREPL report](https://github.com/jasalt/raylib-jlt/blob/main/nrepl-results/REPORT.md),
which the page cites. The platforms differ mainly in volume: macOS traps the
first off-main `InitWindow` because AppKit checks, elsewhere the same rule holds
but breaking it degrades instead of aborting.

## Checks

`bb check`, `bb lint:strict` and `bb lsp:check` all pass locally.
