### PR TITLE
docs: build the site through the shared workflow

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,12 +1,12 @@
 name: Site
 
 # Builds the documentation site on every pull request, and publishes it to
-# GitHub Pages from main. The generator lives in jlt-commons/docs-engine;
-# this repo owns its content, its config in docs/site.edn, and its homepage
-# template.
+# GitHub Pages from main.
 #
-# The engine is pinned to a tag rather than tracking its main branch, so a
-# change over there cannot break these docs without someone choosing it.
+# The build itself lives in jlt-commons/ci-builds, shared by every project so
+# the scaffolding is fixed in one place. What stays here is what is actually
+# this project's: the content under docs/, its config in docs/site.edn, the
+# base path below, and the assertions in docs/check-site.sh.
 
 on:
   push:
@@ -17,103 +17,19 @@ on:
 permissions:
   contents: read
 
-# Deploys must not race, and a half-applied Pages deployment is worse than
-# a slightly stale one, so main is never cancelled. Pull request builds are
-# scoped per ref and cancel their own earlier runs, so a third queued run
-# cannot supersede a second one and show a contributor a cancelled check.
+# Deploys must not race, and a half-applied Pages deployment is worse than a
+# slightly stale one, so main is never cancelled. Pull request builds are
+# scoped per ref and cancel their own earlier runs.
 concurrency:
-  group: site-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
-env:
-  DOCS_ENGINE_REF: v0.2.0
-  BASE_PATH: /raylib-jlt
+  group: site-${ github.ref }
+  cancel-in-progress: ${ github.ref != 'refs/heads/main' }
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Check out the docs engine
-        uses: actions/checkout@v7
-        with:
-          repository: jlt-commons/docs-engine
-          ref: ${{ env.DOCS_ENGINE_REF }}
-          path: .docs-engine
-
-      - name: Install babashka
-        uses: DeLaGuardo/setup-clojure@13.6.1
-        with:
-          bb: latest
-
-      - name: Build
-        working-directory: .docs-engine
-        run: bb build "$GITHUB_WORKSPACE"
-
-      # Everything below has failed in this project's history, in one form or
-      # another, and each check names the symptom a reader would otherwise
-      # have to diagnose from a rendered page.
-      - name: Check the build
-        run: |
-          set -euo pipefail
-          out=_site
-
-          test -f "$out/index.html"       || { echo "no homepage generated"; exit 1; }
-          test -f "$out/guide/index.html" || { echo "no guide page generated"; exit 1; }
-          test -f "$out/css/screen.css"   || { echo "static assets missing"; exit 1; }
-
-          # The gallery is the point of this site. A missing asset dir is a
-          # warning inside the engine, deliberately, so it has to be an error
-          # here or the docs publish with every image broken.
-          gifs=$(find "$out/demos" -name '*.gif' 2>/dev/null | wc -l | tr -d ' ')
-          source_gifs=$(find docs/demos -name '*.gif' | wc -l | tr -d ' ')
-          test "$gifs" = "$source_gifs" \
-            || { echo "copied $gifs demo GIFs, expected $source_gifs"; exit 1; }
-
-          ! grep -rq '{{site-base}}' "$out"/index.html "$out"/guide/*.html \
-            || { echo "unrendered template variable"; exit 1; }
-
-          grep -q 'pre class="mermaid"' "$out/guide/color-by-value.html" \
-            || { echo "mermaid fences were not rewritten"; exit 1; }
-
-          # Since engine v0.2.0 the 3.4 MB bundle loads only where a diagram
-          # exists. Both directions matter: a page with a diagram that does not
-          # load it renders unstyled source text, and a page without one that
-          # does costs every reader 3.4 MB for nothing.
-          grep -q 'mermaid.min.js' "$out/guide/color-by-value.html" \
-            || { echo "a page with a diagram is not loading mermaid"; exit 1; }
-          ! grep -q 'mermaid.min.js' "$out/guide/demos.html" \
-            || { echo "a page with no diagram is loading mermaid"; exit 1; }
-
-          # The failure mode this site's base path exists to prevent. Served at
-          # jlt-commons.github.io/raylib-jlt/, a root-absolute URL loads the
-          # ORGANIZATION site's asset instead of this project's. The page still
-          # renders, wearing the wrong clothes, so nothing but a check catches it.
-          if grep -ohE '(href|src)="/[^"]*"' "$out"/index.html "$out"/404.html "$out"/guide/*.html \
-               | grep -vE "=\"$BASE_PATH/"; then
-            echo "the URLs above escape $BASE_PATH and would resolve against the org site"
-            exit 1
-          fi
-
-          echo "build looks correct: $gifs demo GIFs, every URL under $BASE_PATH"
-
-      - name: Upload the Pages artifact
-        if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: _site
-
-  deploy:
-    if: github.ref == 'refs/heads/main'
-    needs: build
-    runs-on: ubuntu-latest
+  site:
+    uses: jlt-commons/ci-builds/.github/workflows/site.yml@main
+    with:
+      base-path: /raylib-jlt
     permissions:
+      contents: read
       pages: write
       id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - id: deployment
-        uses: actions/deploy-pages@v5

--- a/docs/check-site.sh
+++ b/docs/check-site.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Assertions this project's documentation build must satisfy.
+#
+# Run by the shared site workflow in jlt-commons/ci-builds against the freshly
+# built _site, with BASE_PATH exported. Lifted verbatim out of this repo's own
+# site.yml when the build scaffolding moved to the shared workflow, so every
+# check here predates that move and still means what it did.
+#
+# Run it locally the same way:
+#   bb site:build && BASE_PATH=/raylib-jlt bash docs/check-site.sh
+
+set -euo pipefail
+out=_site
+
+test -f "$out/index.html"       || { echo "no homepage generated"; exit 1; }
+test -f "$out/guide/index.html" || { echo "no guide page generated"; exit 1; }
+test -f "$out/css/screen.css"   || { echo "static assets missing"; exit 1; }
+
+# The gallery is the point of this site. A missing asset dir is a
+# warning inside the engine, deliberately, so it has to be an error
+# here or the docs publish with every image broken.
+gifs=$(find "$out/demos" -name '*.gif' 2>/dev/null | wc -l | tr -d ' ')
+source_gifs=$(find docs/demos -name '*.gif' | wc -l | tr -d ' ')
+test "$gifs" = "$source_gifs" \
+  || { echo "copied $gifs demo GIFs, expected $source_gifs"; exit 1; }
+
+! grep -rq '{{site-base}}' "$out"/index.html "$out"/guide/*.html \
+  || { echo "unrendered template variable"; exit 1; }
+
+grep -q 'pre class="mermaid"' "$out/guide/color-by-value.html" \
+  || { echo "mermaid fences were not rewritten"; exit 1; }
+
+# Since engine v0.2.0 the 3.4 MB bundle loads only where a diagram
+# exists. Both directions matter: a page with a diagram that does not
+# load it renders unstyled source text, and a page without one that
+# does costs every reader 3.4 MB for nothing.
+grep -q 'mermaid.min.js' "$out/guide/color-by-value.html" \
+  || { echo "a page with a diagram is not loading mermaid"; exit 1; }
+! grep -q 'mermaid.min.js' "$out/guide/demos.html" \
+  || { echo "a page with no diagram is loading mermaid"; exit 1; }
+
+# The failure mode this site's base path exists to prevent. Served at
+# jlt-commons.github.io/raylib-jlt/, a root-absolute URL loads the
+# ORGANIZATION site's asset instead of this project's. The page still
+# renders, wearing the wrong clothes, so nothing but a check catches it.
+if grep -ohE '(href|src)="/[^"]*"' "$out"/index.html "$out"/404.html "$out"/guide/*.html \
+     | grep -vE "=\"$BASE_PATH/"; then
+  echo "the URLs above escape $BASE_PATH and would resolve against the org site"
+  exit 1
+fi
+
+echo "build looks correct: $gifs demo GIFs, every URL under $BASE_PATH"


### PR DESCRIPTION
Moves this project's docs build onto the shared workflow in [jlt-commons/ci-builds](https://github.com/jlt-commons/ci-builds/blob/main/.github/workflows/site.yml).

**What moved.** The scaffolding in `site.yml` was identical to the other four projects' for 72 lines, differing only in `BASE_PATH` and one comment. All five already pinned the same docs-engine tag. That now lives once in `ci-builds`; this file is a 35-line caller.

**What did not move, deliberately.** The `Check the build` step was *not* shared boilerplate — 41 to 50 lines per project, asserting on page names that exist in that project, counting that project's own asset directory, grepping for its own name. Folding those into one shared block would have quietly deleted real assertions. They move **verbatim** into `docs/check-site.sh`, which the shared workflow runs against the built `_site` with `BASE_PATH` exported. Nothing reworded, nothing dropped.

A side benefit: those checks are now runnable locally, which they were not while trapped in a workflow step.

```
bb site:build && BASE_PATH=<base-path> bash docs/check-site.sh
```

**The Pages deploy stays here** because it has to — a Pages site belongs to the repository that owns it. That constraint is why this is a reusable workflow rather than something `ci-builds` runs centrally.

Verified before pushing: the caller parses as YAML and `docs/check-site.sh` passes `bash -n`. The PR's own Site build is the real test.