### PR TITLE
Sync the docs to 122 examples and the jolt 0.8.0 floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,41 @@ Examples read at <https://jlt-commons.github.io/raylib-jlt/>.
 
 ## Unreleased
 
+- **BREAKING: the suite now needs jolt 0.8.0 or newer.** `deps.edn` declares
+  `:jolt/min-version "0.8.0"`, so a runtime that reads the key and sits below the
+  floor refuses to load the project instead of running it. jolt 0.8.0 moved
+  `jolt.ffi/write`'s value argument in front of the offset, `(write p type value offset)`, matching
+  `babashka.ffi`. All 25 call sites in the binding layer were rewritten. The two
+  spellings are both integers, so nothing raises and nothing warns: an older jolt
+  would write every camera, matrix and uniform field to the wrong address and
+  draw something subtly wrong rather than failing. The floor is a forward
+  guard rather than a fix for that: jolt reads `:jolt/min-version` only from the
+  release that added the key, and that commit is the direct child of the one that
+  moved `ffi/write`, so every runtime old enough to have the old order is also too
+  old to read the key and ignores it. It will stop the next break, not this one.
+  jolt v0.8.0 was released on 2026-09-01, so a current jolt satisfies the floor
+  directly. Only a build made from `main` between the `ffi/write` change and that
+  tag needs `JOLT_SKIP_MIN_VERSION=1`, because it reports a version like
+  `v0.7.29-25-gd4e92a43` whose numeric prefix sorts below 0.8.0 despite carrying
+  the new behaviour. `read` and `write-field` are unchanged, and this suite has no
+  `[:array ...]` layouts, so jolt's other breaking change in the same release does
+  not reach it.
+
+- **Three more examples, taking the suite to 122.** `helitorus` (3d) winds a
+  helix around a torus and sweeps it into a tube, doing projection, lighting and
+  hidden-surface removal in jolt rather than in raylib, which shows how far the
+  rlgl layer reaches on its own. `doom` (3d) is a textured raycaster: one ray per
+  screen column, each hit drawn as a vertical strip, with the per-column distance
+  doubling as the z-buffer the sprite pass tests against. It sits next to
+  `first-person-maze` deliberately, since that walks real 3D cubes under a
+  `Camera3D` and this uses no 3D geometry at all. `pacman` (games) has the four
+  classic ghost personalities and buffers a turn until the next legal tile
+  centre. Four new bindings come with them:
+  `rl-disable-backface-culling` / `rl-enable-backface-culling`, and
+  `set-mouse-position` with `hide-cursor` / `show-cursor` for `doom`'s
+  mouse-look. None of the three is recorded yet, so the galleries still show 119
+  recordings.
+
 - **The site's diagrams fit the column they are drawn in.** The homepage's
   "How it fits together" flowchart was laid out left to right and came out
   1458px wide against a 1120px content column, so the browser scaled the whole

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,13 +14,32 @@ this repo's `docs/guide/`; edit the Markdown here, never the site.
 You need two things:
 
 ```sh
-jolt --version    # any recent jolt; tested against v0.7.16
+jolt --version    # jolt 0.8.0 or newer (deps.edn declares :jolt/min-version)
 bb lib:check      # is the native libraylib installed for this OS/arch?
 ```
 
 If `bb lib:check` says no, `bb lib:install` will install it via your platform's
 package manager (brew / pacman / apt / dnf / zypper / apk), or `bb lib:install
 --dry-run` prints the command it would run so you can do it yourself.
+
+If any task stops with `this project needs jolt 0.8.0 or newer`, your jolt is below
+the floor `deps.edn` declares. jolt v0.8.0 was released on 2026-09-01, so installing
+a current jolt is the fix. The one exception is a build from `main` made between the
+`ffi/write` change and that tag: it reports something like `v0.7.29-25-gd4e92a43`,
+whose numeric prefix sorts below the floor even though it carries the new behaviour.
+Prefix the command with `JOLT_SKIP_MIN_VERSION=1` in that case only. The
+[README](README.md#jolt) explains why the floor exists, and why it could not have
+caught an older jolt in the first place.
+
+CI and your machine can be on different jolts, and that is deliberate rather than
+a fault. The workflow pins `JOLT_VERSION` (0.8.0 at the time of writing), while
+local development here tracks jolt's `main`, which runs ahead of the pin: 45
+commits ahead as of 2026-09-02. So a regression introduced upstream shows up
+locally and stays invisible in CI, and an upstream fix does the opposite. If a
+failure you see locally goes green in CI, compare `jolt --version` on both sides
+before concluding the failure was yours. To test a different runtime without
+moving the pin, run the workflow via `workflow_dispatch` with the `jolt-version`
+input.
 
 [babashka](https://babashka.org) is optional but makes everything friendlier:
 every example has a `bb <name>` task. Without it, use `jolt -M:<alias>` directly.

--- a/README.md
+++ b/README.md
@@ -56,12 +56,48 @@ the task tells you so if the tool is absent.
 ### jolt
 
 ```sh
-jolt --version               # requires jolt v0.7.23 or newer
+jolt --version               # requires jolt 0.8.0 or newer
 ```
 
-**0.7.23 is a hard floor**, not a suggestion: `DrawCircleGradient` is bound with
-`[:by-value [:struct ...]]`, which does not exist before it. Older jolt fails at
-compile with a type error rather than at runtime.
+`deps.edn` declares `:jolt/min-version "0.8.0"`, and jolt v0.8.0 was released on
+2026-09-01, so a current jolt satisfies it and nothing extra is needed. The reason
+for the floor is `jolt.ffi/write`: as of 0.8.0 it takes the value *before* the
+offset, `(write p type value offset)`, which is `babashka.ffi`'s order, where it
+used to be `(write p type offset value)`. Both spellings are integers, so nothing
+raises and nothing warns. An older jolt running this code writes every camera and
+uniform field to the wrong address, then draws something subtly wrong instead of
+failing.
+
+**The floor is a forward guard, not protection against that particular break.**
+jolt honours `:jolt/min-version` only from the release that introduced the key, and
+that commit is the direct child of the one that moved `ffi/write`. The two sets
+don't overlap: any jolt new enough to read the key already has the new argument
+order, and any jolt with the old order is too old to know the key and ignores it,
+exactly as it ignores every key it doesn't recognise. So on jolt v0.7.29 or below
+nothing refuses anything, the suite still compiles, and the writes land in the wrong
+place. Upgrading is the only thing that fixes that; the declaration earns its place
+against the *next* break.
+
+One case still needs the escape hatch. A jolt built from `main` between the
+`ffi/write` change and the v0.8.0 tag reports a version like
+`v0.7.29-25-gd4e92a43`, whose numeric prefix reads as `0.7.29` and therefore sorts
+below the floor even though it carries the new behaviour. A build tagged v0.8.0 or
+later parses as `[0 8 0]` and passes normally. For the in-between case:
+
+```sh
+JOLT_SKIP_MIN_VERSION=1 bb check
+```
+
+Reach for it only when you know your build is past the `ffi/write` change. On jolt
+v0.7.29 or below it is a no-op, because no such release reads the key at all, so it
+is never a substitute for checking what you are actually running. Installing v0.8.0
+is the better answer in both cases.
+
+An older floor still appears in the guide pages, and it is still accurate as history:
+**jolt 0.7.23** is what added `[:by-value [:struct ...]]`, which `DrawCircleGradient`
+is bound with, and below that the binding fails at compile with a type error. So
+0.7.23 is where these bindings became expressible, while 0.8.0 is what the suite
+needs today.
 
 One thing to know if you edit the shared binding layer
 (`src/net/b12n/raylib_jlt/raylib.clj`): since **jolt 0.4.0** unresolved symbols are a
@@ -398,7 +434,7 @@ passing is the cause; switch to the rlgl-matrix approach.
 The same pointer approach scales to 3D: `BeginMode3D(Camera3D)` takes a 44-byte
 struct (three `Vector3` + `fovy` + `projection`), which is `>16` bytes so it goes
 by pointer too; `net.b12n.raylib-jlt.raylib/with-camera-3d` builds it (`ffi/alloc` 44 +
-`ffi/write` nine floats + an `:int`). But 3D shape helpers (`DrawCube`,
+`ffi/write` ten floats + an `:int`). But 3D shape helpers (`DrawCube`,
 `DrawSphere`, `DrawLine3D`) take a `Vector3` **by value**, a 12-byte float struct
 passed in FP registers, which the pointer trick does **not** cover. So `camera-3d`
 draws its cube with rlgl immediate mode (`rlVertex3f`, scalar) inside `BeginMode3D`;
@@ -414,7 +450,7 @@ inline.
 
 - [`docs/guide/`](docs/guide/index.md): patterns & pitfalls, each with source
   citations:
-  - [`structs-by-value.md`](docs/guide/structs-by-value.md): `[:by-value [:struct ...]]` in both directions, and the jolt 0.7.23 floor
+  - [`structs-by-value.md`](docs/guide/structs-by-value.md): `[:by-value [:struct ...]]` in both directions, and where the jolt floor comes from
   - [`color-by-value.md`](docs/guide/color-by-value.md): why `Color` crosses the FFI as a packed `:uint`
   - [`struct-by-value-pointer-trick.md`](docs/guide/struct-by-value-pointer-trick.md): `Camera2D`/`Camera3D` by pointer on AArch64 (+ the x86-64 caveat)
   - [`rlgl-immediate-mode.md`](docs/guide/rlgl-immediate-mode.md): the fallback for by-value `Vector2`/`Vector3` geometry, + the matrix stack
@@ -430,6 +466,12 @@ inline.
   `bb record` from `scripts/demo_manifest.edn` (don't hand-edit it), while
   [`docs/guide/demos.md`](docs/guide/demos.md) is the full-size companion to the
   example catalog's thumbnails.
+
+  119 recordings against 122 examples is not a mismatch to fix in the docs.
+  `helitorus`, `doom` and `pacman` landed with their `demo_manifest.edn` entries
+  but have not been recorded yet, and recording is a maintainer step that needs
+  the unreleased capture tool. Run them with `bb helitorus`, `bb doom` or
+  `bb pacman` in the meantime.
 
 - Publishing is automatic. `.github/workflows/site.yml` builds the site on every
   pull request and deploys it from `main`, so a merged docs change is live without

--- a/docs/guide/demos.md
+++ b/docs/guide/demos.md
@@ -1,7 +1,10 @@
 # Full-size demo gallery
 
-Every example at full size, linked from [the example catalog](example-catalog.md)'s
-preview thumbnails. All 119 are here.
+Every recorded example at full size, linked from
+[the example catalog](example-catalog.md)'s preview thumbnails. All 119 recordings
+are here, covering 119 of the suite's 122 examples: `helitorus`, `doom` and
+`pacman` have not been recorded yet, so run them with `bb helitorus`, `bb doom`
+or `bb pacman`.
 
 117 are animated GIFs. Two are still frames: `rectangle-advanced` and
 `rlgl-triangle` draw something fixed and only move when you drive them, so a

--- a/docs/guide/example-catalog.md
+++ b/docs/guide/example-catalog.md
@@ -1,4 +1,4 @@
-# The example catalog: 119 raylib demos in jolt
+# The example catalog: 122 raylib demos in jolt
 
 A map of the whole suite. Each example is one namespace under
 `src/net/b12n/raylib_jlt/`, runnable by a friendly `bb <name>` task or the underlying
@@ -14,7 +14,7 @@ bb info            # the grouped cheat-sheet below
 bb run-all [secs]  # every example, N seconds each (unattended)
 ```
 
-## games (10)
+## games (11)
 
 | preview | `bb` name | shows |
 |---|---|---|
@@ -28,6 +28,7 @@ bb run-all [secs]  # every example, N seconds each (unattended)
 | [<img src="../demos/flappy-bird.gif" width="80">](demos.md#flappy-bird) | `flappy-bird` | flap through the pipe gaps (SPACE) |
 | [<img src="../demos/game-2048.gif" width="80">](demos.md#game-2048) | `game-2048` | 2048: 4x4 tile-merge puzzle (arrow keys) |
 | [<img src="../demos/minesweeper.gif" width="80">](demos.md#minesweeper) | `minesweeper` | reveal/flag grid (mouse L reveal, R flag) |
+| *not recorded yet* | `pacman` | the four classic ghost personalities, buffered turns |
 
 ## core (23)
 
@@ -114,7 +115,7 @@ bb run-all [secs]  # every example, N seconds each (unattended)
 | [<img src="../demos/words-alignment.gif" width="80">](demos.md#words-alignment) | `words-alignment` | align a word inside a box with `MeasureText` |
 | [<img src="../demos/input-box.gif" width="80">](demos.md#input-box) | `input-box` | type into a text box (GetCharPressed) |
 
-## 3d (16)
+## 3d (18)
 
 | preview | `bb` name | shows |
 |---|---|---|
@@ -134,11 +135,21 @@ bb run-all [secs]  # every example, N seconds each (unattended)
 | [<img src="../demos/dna-helix.gif" width="80">](demos.md#dna-helix) | `dna-helix` | a turning double helix with coloured base pairs |
 | [<img src="../demos/yaw-pitch-roll.gif" width="80">](demos.md#yaw-pitch-roll) | `yaw-pitch-roll` | the three aircraft rotations in 3D |
 | [<img src="../demos/first-person-maze.gif" width="80">](demos.md#first-person-maze) | `first-person-maze` | walk a grid maze in first person, with a minimap |
+| *not recorded yet* | `helitorus` | a helix wound around a torus, projected and depth-sorted in jolt |
+| *not recorded yet* | `doom` | a textured raycaster: one ray per screen column, no 3D geometry |
 
-The 3D set stands entirely on two building blocks from
+Most of the 3D set stands on two building blocks from
 [`rlgl-immediate-mode.md`](rlgl-immediate-mode.md) and
 [`struct-by-value-pointer-trick.md`](struct-by-value-pointer-trick.md): `with-camera-3d`
 (the camera, by pointer) and `cube!` (the geometry, by rlgl vertices).
+
+`helitorus` and `doom` are the two that don't, and that is why they're worth
+reading next to the others. `helitorus` does projection, lighting and
+hidden-surface removal itself, so it shows how far the rlgl layer alone reaches
+without a `Camera3D`. `doom` casts one ray per screen column and draws each hit as
+a textured vertical strip, with no 3D geometry and no camera matrix anywhere; put
+it beside `first-person-maze`, which walks a grid of real cubes under a
+`Camera3D`, and the two techniques for the same picture sit side by side.
 
 ## generative (9)
 
@@ -177,7 +188,9 @@ native memory rather than loaded from a file. See
 
 GLSL compiled at runtime and run over a full-screen quad. raylib's `LoadShader`
 returns a `Shader` by value, which needed jolt's `[:by-value [:struct ...]]` -
-so these are the first examples with a hard jolt floor (0.7.23). The source
+so these were the first examples to put a hard jolt floor under the suite, at
+0.7.23. The floor is higher now, 0.8.0, for an unrelated `ffi/write` change the
+[README](../../README.md#jolt) explains. The source
 lives as a string in each namespace rather than a `.glsl` file, so an example
 stays one self-contained file.
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -16,7 +16,7 @@ looks needlessly indirect and you want the ABI reason behind it.
 
 ## What raylib-jlt is
 
-A community suite of 119 raylib examples: the classic core/shapes/text demos, a
+A community suite of 122 raylib examples: the classic core/shapes/text demos, a
 handful of games (asteroids, tetris, pong, vampire-survivors), and a 3D set
 (orbiting cameras, waving cubes, an rlgl solar system), each a small Clojure
 namespace on top of one shared binding layer, `net.b12n.raylib-jlt.raylib`.
@@ -118,7 +118,7 @@ Nothing about `jolt.ffi` is raylib-specific: it binds any C ABI symbol. The
 
 ### Orientation
 
-- ✅ [`example-catalog.md`](example-catalog.md): a tour of all 119 examples grouped
+- ✅ [`example-catalog.md`](example-catalog.md): a tour of all 122 examples grouped
   games / core / shapes / text / 3d / generative / textures, what each demonstrates, and the
   five-touchpoint recipe for adding one (source ns + `deps.edn` alias +
   `check.clj` require + `examples_registry.clj` row + `bb.edn` task). Read this

--- a/docs/guide/struct-by-value-pointer-trick.md
+++ b/docs/guide/struct-by-value-pointer-trick.md
@@ -55,12 +55,12 @@ the struct with `ffi/alloc` + six little-endian `ffi/write :float`s:
     :or {offset-x 0 offset-y 0 target-x 0 target-y 0 rotation 0 zoom 1.0}} f]
   (let [p (ffi/alloc 24)]
     (try
-      (ffi/write p :float 0  (double offset-x))
-      (ffi/write p :float 4  (double offset-y))
-      (ffi/write p :float 8  (double target-x))
-      (ffi/write p :float 12 (double target-y))
-      (ffi/write p :float 16 (double rotation))
-      (ffi/write p :float 20 (double zoom))
+      (ffi/write p :float (double offset-x) 0)
+      (ffi/write p :float (double offset-y) 4)
+      (ffi/write p :float (double target-x) 8)
+      (ffi/write p :float (double target-y) 12)
+      (ffi/write p :float (double rotation) 16)
+      (ffi/write p :float (double zoom) 20)
       (begin-mode-2d-ptr p)
       (f)
       (end-mode-2d)
@@ -83,14 +83,14 @@ flowchart LR
 ## Camera3D is the same recipe, bigger
 
 `Camera3D` is 44 bytes: three `Vector3` (position, target, up) + a `float fovy` +
-an `int projection`. `with-camera-3d` allocates 44 and writes nine floats then one
+an `int projection`. `with-camera-3d` allocates 44 and writes ten floats then one
 int:
 
 ```clojure
 (let [p (ffi/alloc 44)]
-  ;; … nine (ffi/write p :float …) at offsets 0..36 …
-  (ffi/write p :float 36 (double fovy))
-  (ffi/write p :int   40 (int projection))   ; 0 = perspective
+  ;; … nine (ffi/write p :float …) at offsets 0..32 …
+  (ffi/write p :float (double fovy) 36)
+  (ffi/write p :int (int projection) 40)     ; 0 = perspective
   (begin-mode-3d-ptr p) (f) (end-mode-3d))
 ```
 

--- a/docs/guide/structs-by-value.md
+++ b/docs/guide/structs-by-value.md
@@ -5,9 +5,17 @@ C struct by value, and each works around that in a different way. jolt
 **0.7.23** added `[:by-value ...]` and the workarounds became optional. This
 page is what to write now.
 
-The suite pins jolt 0.7.23 as a hard floor for exactly this reason - it is the
-first version where `LoadShader` is callable at all, and the ten `shaders`
-examples all depend on it.
+0.7.23 is the first version where `LoadShader` is callable at all, and the ten
+`shaders` examples all depend on it, so nothing in this page works below it.
+
+The suite's declared floor is higher now. `deps.edn` says
+`:jolt/min-version "0.8.0"`, for an unrelated reason: 0.8.0 moved `ffi/write`'s
+value argument in front of the offset, and the old and new spellings are both
+integers, so an older runtime writes to the wrong place without complaining. The
+declaration is a forward guard rather than a cure, since a jolt old enough to have
+the old order is also too old to read the key. See the
+[README's jolt requirements](../../README.md#jolt) for the full story and for
+`JOLT_SKIP_MIN_VERSION=1`.
 
 ## Both directions, one descriptor
 

--- a/docs/guide/textures-via-rlgl.md
+++ b/docs/guide/textures-via-rlgl.md
@@ -77,7 +77,7 @@ byte-for-byte the RGBA8 layout OpenGL wants. That makes each texel a single
     (try
       (dotimes [y h]
         (dotimes [x w]
-          (ffi/write buf :uint (* 4 (+ x (* y w))) (f x y))))
+          (ffi/write buf :uint (f x y) (* 4 (+ x (* y w))))))
       (let [id (rl-load-texture buf w h PIXELFORMAT-R8G8B8A8 1)]
         (texture-filter! id RL-TEXTURE-FILTER-NEAREST)
         (texture-wrap! id RL-TEXTURE-WRAP-REPEAT)

--- a/docs/site.edn
+++ b/docs/site.edn
@@ -11,7 +11,7 @@
  :base-path   "/raylib-jlt"
 
  :title       "raylib-jlt"
- :description "115 raylib examples in Jolt: native Clojure on Chez Scheme, calling libraylib directly over its C ABI through jolt.ffi. No wrapper library, no codegen, no C shim."
+ :description "122 raylib examples in Jolt: native Clojure on Chez Scheme, calling libraylib directly over its C ABI through jolt.ffi. No wrapper library, no codegen, no C shim."
 
  ;; docs/demos holds 117 recorded GIFs plus 2 still frames, referenced as
  ;; ../demos/*.gif. Without this the pages render with every image broken.

--- a/docs/templates/home.html
+++ b/docs/templates/home.html
@@ -60,13 +60,13 @@
   <div class="hero-inner">
     <h1>raylib examples in Jolt</h1>
     <p class="tagline">
-      119 <strong>raylib</strong> examples written in <strong>Jolt</strong>,
+      122 <strong>raylib</strong> examples written in <strong>Jolt</strong>,
       native Clojure on Chez Scheme, no JVM. They call the real
       <code>libraylib</code> directly over its C ABI through
       <code>jolt.ffi</code>: no wrapper library, no codegen, no C shim.
     </p>
     <div class="hero-actions">
-      <a class="btn btn-primary" href="{{site-base}}/guide/example-catalog.html">Browse all 119</a>
+      <a class="btn btn-primary" href="{{site-base}}/guide/example-catalog.html">Browse all 122</a>
       <a class="btn" href="{{site-base}}/guide/index.html">Read the guide</a>
     </div>
   </div>
@@ -166,7 +166,7 @@
     <h2>How it fits together</h2>
     <pre class="mermaid">
 flowchart TB
-  subgraph ex["119 example namespaces"]
+  subgraph ex["122 example namespaces"]
     e["pong · boids · tetris<br/>camera-3d · penrose-tiling · …"]
   end
   subgraph shared["net.b12n.raylib-jlt.raylib: one shared layer"]
@@ -206,7 +206,7 @@ flowchart TB
         <p><code>RAYLIB_APP_AUTO_QUIT_MS</code> closes the window on a timer and <code>RAYLIB_APP_SHOT</code> dumps a frame to PNG, so a windowed example can prove itself unattended.</p>
       </div>
       <div class="feat">
-        <h4>A compile gate over all 119</h4>
+        <h4>A compile gate over all 122</h4>
         <p><code>bb check</code> requires every example namespace headlessly. No window, no JVM, and it catches a broken binding across the whole suite at once.</p>
       </div>
       <div class="feat">
@@ -230,10 +230,10 @@ bb lib:install     # …install it via brew / pacman / apt / dnf / zypper / apk
 bb info            # grouped cheat-sheet of every example
 bb tetris          # run one (opens a window)
 bb run-all 10      # demo reel: every example, 10s each
-bb check           # headless compile-check of all 119, no window</code></pre>
+bb check           # headless compile-check of all 122, no window</code></pre>
     <p>
-      Needs <code>jolt</code> (tested against v0.7.16) and a system
-      <code>libraylib</code>.
+      Needs <code>jolt</code> 0.8.0 or newer (<code>deps.edn</code> declares
+      <code>:jolt/min-version</code>) and a system <code>libraylib</code> 6.0+.
       <a href="https://babashka.org" target="_blank" rel="noopener">babashka</a>
       is optional but gives every example a friendly task; without it each one
       is a <code>joltc -M:&lt;alias&gt;</code> away.


### PR DESCRIPTION
PRs #9 and #10 landed without the docs catching up. This is the catch-up pass.

## Counts

122 everywhere, measured from `examples_registry.clj` rather than derived from the old number: the catalog title plus its `games (11)` and `3d (18)` headings, the guide index, the homepage, and `docs/site.edn`'s meta description, which had drifted two counts behind at **115**. `helitorus`, `doom` and `pacman` get catalog rows.

Recordings stay at **119**, and that is not a mismatch to fix. The three new examples have `demo_manifest.edn` entries but no GIF yet, so the README and `demos.md` say so rather than leaving a reader to wonder why the gallery is short.

## `ffi/write`

The samples in `struct-by-value-pointer-trick.md` and `textures-via-rlgl.md` were showing the **old** argument order as live code. They now match the source exactly.

## The jolt floor

Rewritten across README, CONTRIBUTING, CHANGELOG and `structs-by-value.md`, and it now says something `deps.edn` does not: **the floor cannot catch the break that motivated it.** jolt honours `:jolt/min-version` only from the release that added the key, and that commit is the direct child of the one that moved `ffi/write`. So every runtime with the old order is too old to read the key and ignores it. The declaration guards the *next* break. Upstream now states the same in `jolt-lang/jolt@31e6a19c`.

`0.7.23` references stay where they are history, since that is still the release that added `[:by-value [:struct ...]]`.

CONTRIBUTING also notes that CI pins `JOLT_VERSION` (0.8.0, from #11) while local development tracks jolt `main`, so a local-only failure is worth checking with `jolt --version` on both sides before assuming it is yours.

## Two accuracy fixes found along the way

- README and the pointer-trick guide both said `with-camera-3d` writes **nine** floats. The source writes **ten**, plus the int.
- The catalog said the 3D set stands entirely on `with-camera-3d` and `cube!`, which `helitorus` and `doom` contradict: one does its own projection and depth sort, the other casts rays with no 3D geometry or camera matrix at all.

## Verification

Against jolt `v0.8.0-45-g5e0e7a96`:

- `bb check:registration` — 122 across all five touchpoints
- `bb check` — all 122 namespaces, no `JOLT_SKIP_MIN_VERSION` needed
- `bb site:build` + `BASE_PATH=/raylib-jlt bash docs/check-site.sh` — 117 GIFs, every URL under the base path
- One render per distinct `ffi/write` call site. `camera2d` (15478 bytes) and `camera-3d` (30950) are byte-identical across three jolt builds; `texture-procedural`, `render-texture` and `custom-uniform` all visually correct.

Docs only. No source changes.