### PR TITLE
Document bb test as a gate, and correct the CI pin version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Prefix the command with `JOLT_SKIP_MIN_VERSION=1` in that case only. The
 caught an older jolt in the first place.
 
 CI and your machine can be on different jolts, and that is deliberate rather than
-a fault. The workflow pins `JOLT_VERSION` (0.8.0 at the time of writing), while
+a fault. The workflow pins `JOLT_VERSION` (0.8.1 at the time of writing), while
 local development here tracks jolt's `main`, which runs ahead of the pin: 45
 commits ahead as of 2026-09-02. So a regression introduced upstream shows up
 locally and stays invisible in CI, and an upstream fix does the opposite. If a
@@ -46,13 +46,19 @@ every example has a `bb <name>` task. Without it, use `jolt -M:<alias>` directly
 
 ## Before you open a PR
 
-Run the gates. All three are fast and none needs a JVM at runtime:
+Run the gates. All four are fast and none needs a JVM at runtime:
 
 ```sh
 bb check              # headless compile-check of every example (no window opens)
+bb test               # unit suite: ffi/write puts the value where the offset says
 bb lint:strict        # clj-kondo over src, non-zero exit on any finding
 bb lsp:format-check   # clojure-lsp formatting, dry run
 ```
+
+`bb test` earns its place by catching what `bb check` structurally cannot. An
+`ffi/write` argument flip swaps two integers, so the wrong call compiles exactly
+as cleanly as the right one, and a compile-only gate reports green while every
+write lands at the wrong address.
 
 `bb lsp:fix` applies formatting and ns cleanup in place if `lsp:format-check`
 complains. **Formatting is owned by clojure-lsp, not cljfmt**; please don't run

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ bb bouncing-ball        # run one example (opens a window)
 bb run following-eyes   # …or run one by argument
 bb run-all [secs]       # demo reel / smoke test: every example, N seconds each (default 15)
 bb check                # headless compile-check of every example (no window)
+bb test                 # unit suite: ffi/write argument order
 bb lib:check            # is the native libraylib installed for this OS/arch?
 bb lib:install          # install libraylib via the platform package manager
 bb tasks                # raw babashka task list
@@ -206,9 +207,12 @@ bb check:positional-args         # find fns with 3+ positional args (report only
 bb check:positional-args:strict  # bb check:positional-args, but exit non-zero if any found
 ```
 
-`bb check` and `bb lint`/`bb lsp:format-check` are the gates worth running before a
-commit: `check` compiles every example namespace, `lint` runs clj-kondo (static
-analysis), `lsp:format-check` runs clojure-lsp (formatting). **Formatting is owned
+`bb check`, `bb test` and `bb lint`/`bb lsp:format-check` are the gates worth
+running before a commit: `check` compiles every example namespace, `test` round-trips
+`ffi/write` to prove the value lands where the offset says, `lint` runs clj-kondo
+(static analysis), `lsp:format-check` runs clojure-lsp (formatting). `check` alone
+cannot catch an `ffi/write` argument flip, because both arguments are integers and
+the swapped call compiles cleanly, which is what `test` is there for. **Formatting is owned
 by clojure-lsp, not cljfmt**; the two disagree on some compact literal tables
 (e.g. `digital_clock.clj`'s seven-segment map), so only one formatter runs against
 `src`; clojure-lsp was chosen so `lsp:clean-ns` (no cljfmt equivalent) and
@@ -520,7 +524,7 @@ The [example catalog](docs/guide/example-catalog.md) walks through all four unde
 
 New examples are welcome; the suite is deliberately mechanical to grow, and the
 four touchpoints above are the whole recipe. See [`CONTRIBUTING.md`](CONTRIBUTING.md)
-for setup, the three pre-PR gates (`bb check`, `bb lint:strict`,
+for setup, the four pre-PR gates (`bb check`, `bb test`, `bb lint:strict`,
 `bb lsp:format-check`), and what to know before touching the shared binding layer.
 
 ## License


### PR DESCRIPTION
Follow-up to #13. Two commits landed after it and left the docs slightly behind.

## `bb test` was invisible

`2b54a76` added the first tests this project has had, and no page mentioned them. Three places enumerated the gates and all three stopped at check/lint/format:

- `README.md` command list
- `README.md` "the gates worth running before a commit"
- `README.md` footer, "the three pre-PR gates"
- `CONTRIBUTING.md` "Run the gates. All three are fast"

So a contributor reading any of them would skip the one gate that can catch an `ffi/write` argument flip.

The docs now say *why* it earns its place, not just that it exists: both arguments are integers, so a swapped call compiles exactly as cleanly as the right one, and a compile-only gate reports green while every write lands at the wrong address. That is the failure `2b54a76`'s own commit message describes, and it is worth a reader understanding before they decide which gates to bother with.

## The CI pin moved

`3c1d04f` moved `JOLT_VERSION` to 0.8.1, so CONTRIBUTING's note about the CI/local split named the wrong version.

**`:jolt/min-version` deliberately stays at 0.8.0 and every reference to the floor is unchanged.** The floor states what a consumer needs and nothing here needs 0.8.1, exactly as `3c1d04f`'s message argues. Only the sentence describing the CI pin was stale.

## Verification

All gates green against jolt `v0.8.0-45-g5e0e7a96`:

- `bb check` — all 122 namespaces
- `bb test` — 2 tests, 21 assertions
- `bb check:registration` — 122 across five touchpoints
- `bb site:build` + `BASE_PATH=/raylib-jlt bash docs/check-site.sh` — 117 GIFs, every URL under the base path

Docs only. No source changes.